### PR TITLE
create the client secret in the same reconciliation run that the A0Cl…

### DIFF
--- a/src/Alethic.Auth0.Operator/Controllers/V1TenantEntityController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1TenantEntityController.cs
@@ -653,7 +653,16 @@ namespace Alethic.Auth0.Operator.Controllers
 
             // Update lastConf to reflect the applied configuration to prevent false drift detection
             var appliedJson = TransformToNewtonsoftJson<TConf, object>(conf);
-            return TransformToSystemTextJson<Hashtable>(appliedJson);
+            var result = TransformToSystemTextJson<Hashtable>(appliedJson);
+
+            // Preserve Auth0-generated credentials from the original response
+            // These are needed for secret creation and are not part of the spec configuration
+            if (lastConf?.ContainsKey("client_id") == true)
+                result["client_id"] = lastConf["client_id"];
+            if (lastConf?.ContainsKey("client_secret") == true)
+                result["client_secret"] = lastConf["client_secret"];
+
+            return result;
         }
 
         private async Task<(TEntity updatedEntity, bool needsSecretCreationRetry)> FinalizeReconciliation(TEntity entity, IManagementApiClient api, Hashtable? lastConf, CancellationToken cancellationToken)


### PR DESCRIPTION
When the `A0Client` resource is created for the first time, the operator discards the `client_secret` value and do not create the required k8s `Secret`. It's only created in the next reconciliation execution:

See:
```json
{"timestamp":"2025-12-16T19:41:46Z","message":"A0Client creating client in Auth0 with name: my-auth0-client","entityTypeName":"A0Client","clientName":"my-auth0-client","status":"info"}
{"timestamp":"2025-12-16T19:41:46Z","message":"A0Client successfully created client in Auth0 with ID: REDACTED and name: my-auth0-client in 257.6759ms","entityTypeName":"A0Client","clientId":"REDACTED","clientName":"my-auth0-client","durationMs":257.6759,"status":"info"}
{"timestamp":"2025-12-16T19:41:46Z","message":"*** A0Client my-namespace/my-auth0-client CONFIGURATION CHANGES - MODIFIED fields: enabled_connections = [] \u2192 [{id: \u0022REDACTEDV\u0022}]","entityTypeName":"A0Client","entityNamespace":"my-namespace","entityName":"my-auth0-client","changeType":"MODIFIED","modifiedFields":[{"fieldType":1,"fieldName":"enabled_connections","oldValue":"[]","newValue":"[{id: \u0022REDACTED\u0022}]"}],"fieldCount":1,"status":"warning"}
{"timestamp":"2025-12-16T19:41:46Z","message":"*** A0Client my-namespace/my-auth0-client CONFIGURATION CHANGES - REMOVED fields: client_metadata =  \u2192 ","entityTypeName":"A0Client","entityNamespace":"my-namespace","entityName":"my-auth0-client","changeType":"REMOVED","removedFields":[{"fieldType":2,"fieldName":"client_metadata","oldValue":null,"newValue":null}],"fieldCount":1,"status":"warning"}
{"timestamp":"2025-12-16T19:41:46Z","message":"*** A0Client my-namespace/my-auth0-client CONFIGURATION DRIFT DETECTED *** 2 field changes (0 added, 1 modified, 1 removed)","entityTypeName":"A0Client","entityNamespace":"my-namespace","entityName":"my-auth0-client","operation":"drift_detection","totalChanges":2,"addedCount":0,"modifiedCount":1,"removedCount":1,"driftDetected":true,"status":"warning"}
{"timestamp":"2025-12-16T19:41:46Z","message":"*** A0Client my-namespace/my-auth0-client DRIFT DETECTED *** First reconciliation - configuration drift detected between Auth0 and desired state - applying updates","entityTypeName":"A0Client","entityNamespace":"my-namespace","entityName":"my-auth0-client","reconciliationType":"first","action":"applying updates","driftDetected":true,"status":"warning"}
{"timestamp":"2025-12-16T19:41:46Z","message":"A0Client updating client in Auth0 with id: REDACTED and name: my-auth0-client","entityTypeName":"A0Client","clientId":"REDACTED","clientName":"my-auth0-client","driftingFields":["enabled_connections","client_metadata"],"status":"info"}
{"timestamp":"2025-12-16T19:41:46Z","message":"A0Client selective update analysis for client REDACTED: needsClientUpdate=True, needsConnectionUpdate=True","entityTypeName":"A0Client","clientId":"REDACTED","needsClientUpdate":true,"needsConnectionUpdate":true,"driftingFields":["enabled_connections","client_metadata"],"status":"info"}
{"timestamp":"2025-12-16T19:41:47Z","message":"A0Client my-namespace/my-auth0-client client credentials not available, scheduling reconciliation retry in 170s for secret creation","entityTypeName":"A0Client","entityNamespace":"my-namespace","entityName":"my-auth0-client","retryDelaySeconds":170,"status":"info"}
{"timestamp":"2025-12-16T19:41:47Z","message":"A0Client my-namespace/my-auth0-client reconciliation completed successfully in 3196.9051ms","entityTypeName":"A0Client","entityNamespace":"my-namespace","entityName":"my-auth0-client","durationMs":3196.9051,"status":"info"}
{"timestamp":"2025-12-16T19:44:37Z","message":"A0Client my-namespace/my-auth0-client starting reconciliation at 12/16/2025 19:44:37 \u002B00:00","entityTypeName":"A0Client","entityNamespace":"my-namespace","entityName":"my-auth0-client","startTime":"2025-12-16T19:44:37.0492077+00:00","status":"info"}
{"timestamp":"2025-12-16T19:44:37Z","message":"*** SECRET MISSING *** A0Client my-namespace/my-auth0-client referenced secret my-auth0-client-auth0-client which does not exist - creating secret in namespace my-namespace","entityTypeName":"A0Client","entityNamespace":"my-namespace","entityName":"my-auth0-client","secretName":"my-auth0-client-auth0-client","secretNamespace":"my-namespace","operation":"secret_creation_required","status":"warning"}
{"timestamp":"2025-12-16T19:44:37Z","message":"*** SECRET CREATED *** Successfully created secret my-auth0-client-auth0-client in namespace my-namespace for A0Client my-namespace/my-auth0-client","entityTypeName":"A0Client","entityNamespace":"my-namespace","entityName":"my-auth0-client","secretName":"my-auth0-client-auth0-client","secretNamespace":"my-namespace","operation":"secret_created_successfully","status":"warning"}
{"timestamp":"2025-12-16T19:44:37Z","message":"A0Client my-namespace/my-auth0-client referenced secret my-auth0-client-auth0-client: updating due to data changes.","entityTypeName":"A0Client","entityNamespace":"my-namespace","entityName":"my-auth0-client","secretName":"my-auth0-client-auth0-client","status":"info"}
{"timestamp":"2025-12-16T19:44:37Z","message":"A0Client my-namespace/my-auth0-client successfully updated secret my-auth0-client-auth0-client","entityTypeName":"A0Client","entityNamespace":"my-namespace","entityName":"my-auth0-client","secretName":"my-auth0-client-auth0-client","status":"info"}
{"timestamp":"2025-12-16T19:44:37Z","message":"A0Client my-namespace/my-auth0-client scheduling next reconciliation in 3600s","entityTypeName":"A0Client","entityNamespace":"my-namespace","entityName":"my-auth0-client","intervalSeconds":3600,"status":"info"}
{"timestamp":"2025-12-16T19:44:37Z","message":"A0Client my-namespace/my-auth0-client reconciliation completed successfully in 519.5519ms","entityTypeName":"A0Client","entityNamespace":"my-namespace","entityName":"my-auth0-client","durationMs":519.5519,"status":"info"}
```