### PR TITLE
Switch atomic-membership writes to PATCH /connections/{id}/clients (LA-RF-81)

### DIFF
--- a/src/Alethic.Auth0.Operator.Tests/Alethic.Auth0.Operator.Tests.csproj
+++ b/src/Alethic.Auth0.Operator.Tests/Alethic.Auth0.Operator.Tests.csproj
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Auth0.AuthenticationApi" Version="7.40.0" />
-        <PackageReference Include="Auth0.ManagementApi" Version="7.40.0" />
+        <PackageReference Include="Auth0.AuthenticationApi" Version="7.46.0" />
+        <PackageReference Include="Auth0.ManagementApi" Version="7.46.0" />
         <PackageReference Include="System.Text.Json" Version="9.0.0" />
     </ItemGroup>
 

--- a/src/Alethic.Auth0.Operator.Tests/Alethic.Auth0.Operator.Tests.csproj
+++ b/src/Alethic.Auth0.Operator.Tests/Alethic.Auth0.Operator.Tests.csproj
@@ -10,6 +10,7 @@
     <ItemGroup>
         <PackageReference Include="Auth0.AuthenticationApi" Version="7.46.0" />
         <PackageReference Include="Auth0.ManagementApi" Version="7.46.0" />
+        <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="System.Text.Json" Version="9.0.0" />
     </ItemGroup>
 

--- a/src/Alethic.Auth0.Operator.Tests/Controllers/V1ClientControllerEnabledConnectionsTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Controllers/V1ClientControllerEnabledConnectionsTests.cs
@@ -266,6 +266,30 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
                 "The unchanged 'keep' connection should not be PATCHed.");
         }
 
+        // Future-proofing — if Auth0 ever changes GET /api/v2/clients/{id}/connections from the
+        // wrapper {"connections":[...]} shape to a bare array, this test fails loudly instead of
+        // letting GetClientConnectionsAsync silently return an empty list and trigger a re-enable storm.
+        [TestMethod]
+        public async Task GetClientConnections_MalformedResponse_Rethrows()
+        {
+            var handler = new RecordingHandler((req, _) =>
+            {
+                if (req.Method == HttpMethod.Get)
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        // Bare-array body — NOT the wrapper shape ClientConnectionsResponse expects.
+                        Content = new StringContent("[{\"id\":\"con_x\"}]")
+                    };
+                return new HttpResponseMessage(HttpStatusCode.InternalServerError);
+            });
+            var controller = BuildController(handler);
+
+            await Assert.ThrowsExceptionAsync<Newtonsoft.Json.JsonSerializationException>(() =>
+                controller.ReconcileEnabledConnections(new FakeTenantApiAccess(), ClientId,
+                    enabledConnectionRefs: Array.Empty<V1ConnectionReference>(),
+                    defaultNamespace: "default", CancellationToken.None));
+        }
+
         // Single helper for assembling the GET /clients/{id}/connections response body so the
         // orchestration tests above stay focused on the diff/apply logic, not on Auth0's wire shape.
         private static string BuildConnectionsBody(params string[] connectionIds)

--- a/src/Alethic.Auth0.Operator.Tests/Controllers/V1ClientControllerEnabledConnectionsTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Controllers/V1ClientControllerEnabledConnectionsTests.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Alethic.Auth0.Operator.Controllers;
+using Alethic.Auth0.Operator.Core.Models;
 using Alethic.Auth0.Operator.Options;
 using Alethic.Auth0.Operator.Services;
 using KubeOps.Abstractions.Queue;
@@ -35,7 +36,6 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
         private const string TenantBaseUri = "https://example.us.auth0.com/api/v2/";
         private const string ConnectionId = "con_test123";
         private const string ClientId = "abc_clientid";
-        private const string OtherClientId = "xyz_other";
 
         // ---- Golden path: enable issues POST and 2xx clears ----
 
@@ -163,6 +163,8 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
             Assert.AreEqual(2, handler.Requests.Count, "Should retry once after 401");
             Assert.AreEqual("tok-1", handler.Requests[0].Authorization);
             Assert.AreEqual("tok-2", handler.Requests[1].Authorization);
+            Assert.AreEqual(1, tenant.InvalidateCalls,
+                "401 must evict the cached token so the retry gets a freshly-fetched one (H4)");
         }
 
         // ---- Concurrent add + remove of same (connection, client): both calls happen, atomic per call ----
@@ -199,54 +201,86 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
                     CancellationToken.None));
         }
 
-        // ---- 429 is surfaced (same upstream retry wrapper reacts to it) ----
+        // ---- 429 is surfaced as Auth0.Core.Exceptions.RateLimitApiException so the upstream
+        //      RateLimitApiException catch in V1Controller / V1TenantEntityController can read
+        //      X-RateLimit-Reset and requeue per Auth0's documented backoff window. ----
 
         [TestMethod]
-        public async Task DisableClientOnConnection_429_Throws()
+        public async Task DisableClientOnConnection_429_ThrowsRateLimitApiException()
         {
-            var handler = new RecordingHandler((_, __) => new HttpResponseMessage((HttpStatusCode)429)
-                { Content = new StringContent("{\"statusCode\":429,\"error\":\"Too Many Requests\"}") });
+            var resetEpoch = DateTimeOffset.UtcNow.AddSeconds(42).ToUnixTimeSeconds();
+            var handler = new RecordingHandler((_, __) =>
+            {
+                var resp = new HttpResponseMessage((HttpStatusCode)429)
+                {
+                    Content = new StringContent("{\"statusCode\":429,\"error\":\"Too Many Requests\"}")
+                };
+                resp.Headers.TryAddWithoutValidation("X-RateLimit-Reset", resetEpoch.ToString());
+                return resp;
+            });
             var controller = BuildController(handler);
 
-            await Assert.ThrowsExceptionAsync<HttpRequestException>(() =>
+            var ex = await Assert.ThrowsExceptionAsync<global::Auth0.Core.Exceptions.RateLimitApiException>(() =>
                 controller.DisableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
                     CancellationToken.None));
+
+            Assert.IsNotNull(ex.RateLimit, "RateLimit must be populated so the upstream handler can schedule the requeue");
+            Assert.AreEqual(DateTimeOffset.FromUnixTimeSeconds(resetEpoch), ex.RateLimit!.Reset);
         }
 
-        // ---- "Out of band" Auth0 add: an existing enabled client → next reconcile issues DELETE ----
-        //
-        // This test models the controller's external behavior: after Auth0 already has the client
-        // enabled, calling the disable helper issues a single DELETE. The decision to *issue* the
-        // DELETE comes from the reconcile loop's diff against GetClientConnectionsAsync; that piece
-        // is covered by the integration of these primitives at the ApplyConnectionChanges call site.
+        // ---- Orchestrator end-to-end: GET current → diff → POST adds, DELETE removes ----
         [TestMethod]
-        public async Task DisableClientOnConnection_OutOfBandAuth0Add_IssuesDelete()
+        public async Task ReconcileEnabledConnections_MixedAddAndRemove_IssuesPostAndDelete()
         {
-            var handler = new RecordingHandler((_, __) => new HttpResponseMessage(HttpStatusCode.NoContent));
+            const string KeepId = "con_keep";
+            const string AddId = "con_add";
+            const string RemoveId = "con_remove";
+
+            var handler = new RecordingHandler((req, _) =>
+            {
+                if (req.Method == HttpMethod.Get)
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(BuildConnectionsBody(KeepId, RemoveId))
+                    };
+                if (req.Method == HttpMethod.Post)
+                    return new HttpResponseMessage(HttpStatusCode.Created);
+                if (req.Method == HttpMethod.Delete)
+                    return new HttpResponseMessage(HttpStatusCode.NoContent);
+                return new HttpResponseMessage(HttpStatusCode.InternalServerError);
+            });
             var controller = BuildController(handler);
 
-            await controller.DisableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, OtherClientId,
-                CancellationToken.None);
+            await controller.ReconcileEnabledConnections(new FakeTenantApiAccess(), ClientId,
+                new[]
+                {
+                    new V1ConnectionReference { Id = KeepId },
+                    new V1ConnectionReference { Id = AddId }
+                },
+                defaultNamespace: "default", CancellationToken.None);
 
-            Assert.AreEqual(1, handler.Requests.Count);
-            Assert.AreEqual(HttpMethod.Delete, handler.Requests[0].Method);
-            Assert.IsTrue(handler.Requests[0].RequestUri!.AbsolutePath.EndsWith($"/clients/{OtherClientId}"));
+            var post = handler.Requests.SingleOrDefault(r => r.Method == HttpMethod.Post);
+            var delete = handler.Requests.SingleOrDefault(r => r.Method == HttpMethod.Delete);
+
+            Assert.IsNotNull(post, "Expected a POST for the added connection");
+            Assert.IsTrue(post!.RequestUri!.AbsolutePath.EndsWith($"/connections/{AddId}/clients"));
+            StringAssert.Contains(post.Body, $"\"client_id\":\"{ClientId}\"");
+
+            Assert.IsNotNull(delete, "Expected a DELETE for the removed connection");
+            Assert.IsTrue(delete!.RequestUri!.AbsolutePath.EndsWith($"/connections/{RemoveId}/clients/{ClientId}"));
+
+            // Untouched 'keep' connection must not be re-issued.
+            Assert.IsFalse(handler.Requests.Any(r =>
+                r.Method != HttpMethod.Get &&
+                r.RequestUri!.AbsolutePath.Contains($"/connections/{KeepId}/")));
         }
 
-        // ---- Policy gating: if no POST/DELETE is invoked, no HTTP call hits the wire ----
-        //
-        // The new helpers are pure wire-level primitives. The policy gating decision (whether to call
-        // them at all) lives in V1ClientController's reconcile flow, which only enters
-        // ApplyConnectionChanges when an update is permitted. This test pins the contract: no helper
-        // invocation == no HTTP request, so policy-gated callers can confidently skip the helpers.
-        [TestMethod]
-        public void PolicyGating_NoHelperInvocation_NoHttpCalls()
+        // Single helper for assembling the GET /clients/{id}/connections response body so the
+        // orchestration tests above stay focused on the diff/apply logic, not on Auth0's wire shape.
+        private static string BuildConnectionsBody(params string[] connectionIds)
         {
-            var handler = new RecordingHandler((_, __) => new HttpResponseMessage(HttpStatusCode.OK));
-            _ = BuildController(handler);
-
-            Assert.AreEqual(0, handler.Requests.Count,
-                "Constructing the controller must not issue any HTTP calls; policy-gated callers that skip the helpers cause no wire traffic.");
+            var ids = string.Join(",", connectionIds.Select(id => $"{{\"id\":\"{id}\"}}"));
+            return $"{{\"connections\":[{ids}]}}";
         }
 
         // ---- helpers ----
@@ -283,6 +317,7 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
         private sealed class FakeTenantApiAccess : ITenantApiAccess
         {
             public string[] TokenSequence { get; set; } = new[] { "fake-token" };
+            public int InvalidateCalls { get; private set; }
             private int _index;
             public Uri BaseUri => new Uri(TenantBaseUri);
             public Task<string> GetAccessTokenAsync(CancellationToken cancellationToken = default)
@@ -290,6 +325,11 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
                 var tok = TokenSequence[Math.Min(_index, TokenSequence.Length - 1)];
                 _index++;
                 return Task.FromResult(tok);
+            }
+            public Task InvalidateAccessTokenAsync(CancellationToken cancellationToken = default)
+            {
+                InvalidateCalls++;
+                return Task.CompletedTask;
             }
         }
 

--- a/src/Alethic.Auth0.Operator.Tests/Controllers/V1ClientControllerEnabledConnectionsTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Controllers/V1ClientControllerEnabledConnectionsTests.cs
@@ -45,7 +45,8 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
             var controller = BuildController(handler);
             var tenant = new FakeTenantApiAccess();
 
-            await controller.EnableClientOnConnectionAsync(tenant, ConnectionId, ClientId, CancellationToken.None);
+            await controller.EnableClientOnConnectionAsync(tenant, ConnectionId, ClientId,
+                defaultNamespace: "default", CancellationToken.None);
 
             Assert.AreEqual(1, handler.Requests.Count);
             var req = handler.Requests[0];
@@ -69,7 +70,7 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
             var controller = BuildController(handler, logger);
 
             await controller.EnableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
-                CancellationToken.None);
+                defaultNamespace: "default", CancellationToken.None);
 
             var hit = logger.Messages.SingleOrDefault(m =>
                 m.Contains("\"operation\":\"enable_client_on_connection\"")
@@ -89,7 +90,7 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
             var controller = BuildController(handler, logger);
 
             await controller.DisableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
-                CancellationToken.None);
+                defaultNamespace: "default", CancellationToken.None);
 
             var hit = logger.Messages.SingleOrDefault(m =>
                 m.Contains("\"operation\":\"disable_client_on_connection\"")
@@ -110,7 +111,7 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
             var controller = BuildController(handler);
 
             await controller.DisableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
-                CancellationToken.None);
+                defaultNamespace: "default", CancellationToken.None);
 
             Assert.AreEqual(1, handler.Requests.Count);
             var req = handler.Requests[0];
@@ -132,7 +133,7 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
 
             await Assert.ThrowsExceptionAsync<HttpRequestException>(() =>
                 controller.EnableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
-                    CancellationToken.None));
+                    defaultNamespace: "default", CancellationToken.None));
         }
 
         [TestMethod]
@@ -144,7 +145,7 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
 
             await Assert.ThrowsExceptionAsync<HttpRequestException>(() =>
                 controller.DisableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
-                    CancellationToken.None));
+                    defaultNamespace: "default", CancellationToken.None));
         }
 
         // ---- 401 triggers token regeneration and a single retry ----
@@ -163,7 +164,8 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
             var controller = BuildController(handler);
             var tenant = new FakeTenantApiAccess { TokenSequence = new[] { "tok-1", "tok-2" } };
 
-            await controller.EnableClientOnConnectionAsync(tenant, ConnectionId, ClientId, CancellationToken.None);
+            await controller.EnableClientOnConnectionAsync(tenant, ConnectionId, ClientId,
+                defaultNamespace: "default", CancellationToken.None);
 
             Assert.AreEqual(2, handler.Requests.Count, "Should retry once after 401");
             Assert.AreEqual("tok-1", handler.Requests[0].Authorization);
@@ -183,7 +185,7 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
 
             await Assert.ThrowsExceptionAsync<HttpRequestException>(() =>
                 controller.EnableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
-                    CancellationToken.None));
+                    defaultNamespace: "default", CancellationToken.None));
         }
 
         // ---- 429 is surfaced as Auth0.Core.Exceptions.RateLimitApiException so the upstream
@@ -207,7 +209,7 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
 
             var ex = await Assert.ThrowsExceptionAsync<global::Auth0.Core.Exceptions.RateLimitApiException>(() =>
                 controller.DisableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
-                    CancellationToken.None));
+                    defaultNamespace: "default", CancellationToken.None));
 
             Assert.IsNotNull(ex.RateLimit, "RateLimit must be populated so the upstream handler can schedule the requeue");
             Assert.AreEqual(DateTimeOffset.FromUnixTimeSeconds(resetEpoch), ex.RateLimit!.Reset);

--- a/src/Alethic.Auth0.Operator.Tests/Controllers/V1ClientControllerEnabledConnectionsTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Controllers/V1ClientControllerEnabledConnectionsTests.cs
@@ -12,6 +12,7 @@ using Alethic.Auth0.Operator.Services;
 using KubeOps.Abstractions.Queue;
 using KubeOps.KubernetesClient;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -55,6 +56,49 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
             Assert.AreEqual(new Uri(new Uri(TenantBaseUri), $"connections/{ConnectionId}/clients"),
                 req.RequestUri);
             StringAssert.Contains(req.Body, $"\"client_id\":\"{ClientId}\"");
+        }
+
+        // ---- Success path emits a structured info log so production has an audit trail ----
+
+        [TestMethod]
+        public async Task EnableClientOnConnection_Success_EmitsStructuredSuccessLog()
+        {
+            var handler = new RecordingHandler((_, __) =>
+                new HttpResponseMessage(HttpStatusCode.Created) { Content = new StringContent("") });
+            var logger = new RecordingLogger<V1ClientController>();
+            var controller = BuildController(handler, logger);
+
+            await controller.EnableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
+                CancellationToken.None);
+
+            var hit = logger.Messages.SingleOrDefault(m =>
+                m.Contains("\"operation\":\"enable_client_on_connection\"")
+                && m.Contains("succeeded")
+                && m.Contains($"\"connectionId\":\"{ConnectionId}\"")
+                && m.Contains($"\"clientId\":\"{ClientId}\""));
+            Assert.IsNotNull(hit,
+                "Expected a structured info log carrying the operation label, success phrasing, and the connection/client pair.\n"
+                + "Captured messages:\n  - " + string.Join("\n  - ", logger.Messages));
+        }
+
+        [TestMethod]
+        public async Task DisableClientOnConnection_Success_EmitsStructuredSuccessLog()
+        {
+            var handler = new RecordingHandler((_, __) => new HttpResponseMessage(HttpStatusCode.NoContent));
+            var logger = new RecordingLogger<V1ClientController>();
+            var controller = BuildController(handler, logger);
+
+            await controller.DisableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
+                CancellationToken.None);
+
+            var hit = logger.Messages.SingleOrDefault(m =>
+                m.Contains("\"operation\":\"disable_client_on_connection\"")
+                && m.Contains("succeeded")
+                && m.Contains($"\"connectionId\":\"{ConnectionId}\"")
+                && m.Contains($"\"clientId\":\"{ClientId}\""));
+            Assert.IsNotNull(hit,
+                "Expected a structured info log carrying the operation label and success phrasing for the disable path.\n"
+                + "Captured messages:\n  - " + string.Join("\n  - ", logger.Messages));
         }
 
         // ---- Benign 409 ("already enabled") swallowed as no-op ----
@@ -177,7 +221,7 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
             var controller = BuildController(handler);
             var tenant = new FakeTenantApiAccess();
 
-            // No mutex any more — fire concurrently and assert both calls completed.
+            // Concurrent enable + disable of the same pair should both complete independently.
             await Task.WhenAll(
                 controller.EnableClientOnConnectionAsync(tenant, ConnectionId, ClientId, CancellationToken.None),
                 controller.DisableClientOnConnectionAsync(tenant, ConnectionId, ClientId, CancellationToken.None));
@@ -285,7 +329,8 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
 
         // ---- helpers ----
 
-        private static V1ClientController BuildController(HttpMessageHandler handler)
+        private static V1ClientController BuildController(HttpMessageHandler handler,
+            ILogger<V1ClientController>? logger = null)
         {
             var factory = new SingleHandlerHttpClientFactory(handler);
             // DispatchProxy gives us a runtime stub for IKubernetesClient — the helpers under
@@ -295,9 +340,32 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
                 kube: kube,
                 requeue: (EntityRequeue<Alethic.Auth0.Operator.Models.V1Client>)((entity, ts) => { }),
                 cache: new MemoryCache(new MemoryCacheOptions()),
-                logger: NullLogger<V1ClientController>.Instance,
+                logger: logger ?? NullLogger<V1ClientController>.Instance,
                 options: Microsoft.Extensions.Options.Options.Create(new OperatorOptions()),
                 httpClientFactory: factory);
+        }
+
+        /// <summary>
+        /// Captures formatted log messages so tests can assert observability contracts
+        /// (e.g. the structured success log emitted on 2xx connection enable/disable).
+        /// </summary>
+        private sealed class RecordingLogger<T> : ILogger<T>
+        {
+            public List<string> Messages { get; } = new();
+
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                Messages.Add(formatter(state, exception));
+            }
+
+            private sealed class NullScope : IDisposable
+            {
+                public static readonly NullScope Instance = new();
+                public void Dispose() { }
+            }
         }
 
         public class ThrowingKubeProxy : System.Reflection.DispatchProxy

--- a/src/Alethic.Auth0.Operator.Tests/Controllers/V1ClientControllerEnabledConnectionsTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Controllers/V1ClientControllerEnabledConnectionsTests.cs
@@ -21,12 +21,10 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
 {
     /// <summary>
     /// Coverage for <see cref="V1ClientController"/>'s per-client connection enable/disable
-    /// helpers, which replaced the deprecated <c>enabled_clients</c> PATCH flow on
-    /// <c>PATCH /api/v2/connections/{id}</c>.
+    /// helpers, which use Auth0's replacement for the deprecated <c>enabled_clients</c> field:
     ///
-    /// New endpoints exercised here:
-    /// - <c>POST /api/v2/connections/{connectionId}/clients</c> with body <c>{"client_id":"..."}</c>
-    /// - <c>DELETE /api/v2/connections/{connectionId}/clients/{clientId}</c>
+    /// <c>PATCH /api/v2/connections/{connectionId}/clients</c> with body
+    /// <c>[{"client_id":"...","status":true|false}]</c> — success = HTTP 204.
     ///
     /// The controller's <c>IHttpClientFactory</c> dependency lets us inject a fake
     /// <see cref="HttpMessageHandler"/> and assert on the exact request stream.
@@ -38,13 +36,12 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
         private const string ConnectionId = "con_test123";
         private const string ClientId = "abc_clientid";
 
-        // ---- Golden path: enable issues POST and 2xx clears ----
+        // ---- Golden path: enable issues PATCH with status:true and 204 clears ----
 
         [TestMethod]
-        public async Task EnableClientOnConnection_ClientNotYetEnabled_IssuesPostAndSucceeds()
+        public async Task EnableClientOnConnection_ClientNotYetEnabled_IssuesPatchAndSucceeds()
         {
-            var handler = new RecordingHandler((req, _) =>
-                new HttpResponseMessage(HttpStatusCode.Created) { Content = new StringContent("") });
+            var handler = new RecordingHandler((_, __) => new HttpResponseMessage(HttpStatusCode.NoContent));
             var controller = BuildController(handler);
             var tenant = new FakeTenantApiAccess();
 
@@ -52,10 +49,14 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
 
             Assert.AreEqual(1, handler.Requests.Count);
             var req = handler.Requests[0];
-            Assert.AreEqual(HttpMethod.Post, req.Method);
+            Assert.AreEqual(HttpMethod.Patch, req.Method);
             Assert.AreEqual(new Uri(new Uri(TenantBaseUri), $"connections/{ConnectionId}/clients"),
                 req.RequestUri);
             StringAssert.Contains(req.Body, $"\"client_id\":\"{ClientId}\"");
+            StringAssert.Contains(req.Body, "\"status\":true");
+            // Body must be a JSON array (per Auth0 PATCH contract).
+            Assert.IsTrue(req.Body.TrimStart().StartsWith("["),
+                "Auth0 requires the PATCH body to be a JSON array of rows.");
         }
 
         // ---- Success path emits a structured info log so production has an audit trail ----
@@ -63,8 +64,7 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
         [TestMethod]
         public async Task EnableClientOnConnection_Success_EmitsStructuredSuccessLog()
         {
-            var handler = new RecordingHandler((_, __) =>
-                new HttpResponseMessage(HttpStatusCode.Created) { Content = new StringContent("") });
+            var handler = new RecordingHandler((_, __) => new HttpResponseMessage(HttpStatusCode.NoContent));
             var logger = new RecordingLogger<V1ClientController>();
             var controller = BuildController(handler, logger);
 
@@ -101,46 +101,12 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
                 + "Captured messages:\n  - " + string.Join("\n  - ", logger.Messages));
         }
 
-        // ---- Benign 409 ("already enabled") swallowed as no-op ----
+        // ---- Golden path: disable issues PATCH with status:false and 204 clears ----
 
         [TestMethod]
-        public async Task EnableClientOnConnection_AlreadyEnabled_BenignErrorCode_IsNoOp()
+        public async Task DisableClientOnConnection_ClientEnabled_IssuesPatchAndSucceeds()
         {
-            var body = "{\"statusCode\":409,\"error\":\"Conflict\",\"message\":\"Client already enabled\"," +
-                       "\"errorCode\":\"connection_client_already_enabled\"}";
-            var handler = new RecordingHandler((_, __) => new HttpResponseMessage(HttpStatusCode.Conflict)
-                { Content = new StringContent(body) });
-            var controller = BuildController(handler);
-
-            await controller.EnableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
-                CancellationToken.None);
-
-            Assert.AreEqual(1, handler.Requests.Count);
-        }
-
-        // ---- Non-benign 409 (e.g. validation) surfaces as an exception ----
-
-        [TestMethod]
-        public async Task EnableClientOnConnection_409WithUnrelatedErrorCode_Throws()
-        {
-            var body = "{\"statusCode\":409,\"error\":\"Conflict\",\"message\":\"Validation failed\"," +
-                       "\"errorCode\":\"validation_error\"}";
-            var handler = new RecordingHandler((_, __) => new HttpResponseMessage(HttpStatusCode.Conflict)
-                { Content = new StringContent(body) });
-            var controller = BuildController(handler);
-
-            await Assert.ThrowsExceptionAsync<HttpRequestException>(() =>
-                controller.EnableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
-                    CancellationToken.None));
-        }
-
-        // ---- Golden path: disable issues DELETE and 204 clears ----
-
-        [TestMethod]
-        public async Task DisableClientOnConnection_ClientEnabled_IssuesDeleteAndSucceeds()
-        {
-            var handler = new RecordingHandler((_, __) =>
-                new HttpResponseMessage(HttpStatusCode.NoContent));
+            var handler = new RecordingHandler((_, __) => new HttpResponseMessage(HttpStatusCode.NoContent));
             var controller = BuildController(handler);
 
             await controller.DisableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
@@ -148,37 +114,32 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
 
             Assert.AreEqual(1, handler.Requests.Count);
             var req = handler.Requests[0];
-            Assert.AreEqual(HttpMethod.Delete, req.Method);
-            Assert.AreEqual(new Uri(new Uri(TenantBaseUri), $"connections/{ConnectionId}/clients/{ClientId}"),
+            Assert.AreEqual(HttpMethod.Patch, req.Method);
+            Assert.AreEqual(new Uri(new Uri(TenantBaseUri), $"connections/{ConnectionId}/clients"),
                 req.RequestUri);
+            StringAssert.Contains(req.Body, $"\"client_id\":\"{ClientId}\"");
+            StringAssert.Contains(req.Body, "\"status\":false");
         }
 
-        // ---- Benign 404 ("not currently enabled") swallowed as no-op ----
+        // ---- Non-2xx responses surface as exceptions (no benign handling) ----
 
         [TestMethod]
-        public async Task DisableClientOnConnection_NotEnabled_BenignErrorCode_IsNoOp()
+        public async Task EnableClientOnConnection_400_Throws()
         {
-            var body = "{\"statusCode\":404,\"error\":\"Not Found\",\"message\":\"Client not enabled\"," +
-                       "\"errorCode\":\"connection_client_not_found\"}";
-            var handler = new RecordingHandler((_, __) => new HttpResponseMessage(HttpStatusCode.NotFound)
-                { Content = new StringContent(body) });
+            var handler = new RecordingHandler((_, __) => new HttpResponseMessage(HttpStatusCode.BadRequest)
+                { Content = new StringContent("{\"statusCode\":400,\"error\":\"Bad Request\"}") });
             var controller = BuildController(handler);
 
-            await controller.DisableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
-                CancellationToken.None);
-
-            Assert.AreEqual(1, handler.Requests.Count);
+            await Assert.ThrowsExceptionAsync<HttpRequestException>(() =>
+                controller.EnableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
+                    CancellationToken.None));
         }
 
-        // ---- Non-benign 404 (wrong connection_id) surfaces ----
-
         [TestMethod]
-        public async Task DisableClientOnConnection_404WithUnrelatedErrorCode_Throws()
+        public async Task DisableClientOnConnection_403_Throws()
         {
-            var body = "{\"statusCode\":404,\"error\":\"Not Found\",\"message\":\"Connection not found\"," +
-                       "\"errorCode\":\"connection_not_found\"}";
-            var handler = new RecordingHandler((_, __) => new HttpResponseMessage(HttpStatusCode.NotFound)
-                { Content = new StringContent(body) });
+            var handler = new RecordingHandler((_, __) => new HttpResponseMessage(HttpStatusCode.Forbidden)
+                { Content = new StringContent("{\"statusCode\":403,\"error\":\"Forbidden\"}") });
             var controller = BuildController(handler);
 
             await Assert.ThrowsExceptionAsync<HttpRequestException>(() =>
@@ -197,7 +158,7 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
                 calls++;
                 return calls == 1
                     ? new HttpResponseMessage(HttpStatusCode.Unauthorized) { Content = new StringContent("") }
-                    : new HttpResponseMessage(HttpStatusCode.Created) { Content = new StringContent("") };
+                    : new HttpResponseMessage(HttpStatusCode.NoContent);
             });
             var controller = BuildController(handler);
             var tenant = new FakeTenantApiAccess { TokenSequence = new[] { "tok-1", "tok-2" } };
@@ -209,26 +170,6 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
             Assert.AreEqual("tok-2", handler.Requests[1].Authorization);
             Assert.AreEqual(1, tenant.InvalidateCalls,
                 "401 must evict the cached token so the retry gets a freshly-fetched one (H4)");
-        }
-
-        // ---- Concurrent add + remove of same (connection, client): both calls happen, atomic per call ----
-
-        [TestMethod]
-        public async Task AddAndRemove_SamePair_BothCallsIssuedDeterministically()
-        {
-            var handler = new RecordingHandler((req, _) =>
-                new HttpResponseMessage(req.Method == HttpMethod.Post ? HttpStatusCode.Created : HttpStatusCode.NoContent));
-            var controller = BuildController(handler);
-            var tenant = new FakeTenantApiAccess();
-
-            // Concurrent enable + disable of the same pair should both complete independently.
-            await Task.WhenAll(
-                controller.EnableClientOnConnectionAsync(tenant, ConnectionId, ClientId, CancellationToken.None),
-                controller.DisableClientOnConnectionAsync(tenant, ConnectionId, ClientId, CancellationToken.None));
-
-            Assert.AreEqual(2, handler.Requests.Count);
-            Assert.IsTrue(handler.Requests.Any(r => r.Method == HttpMethod.Post));
-            Assert.IsTrue(handler.Requests.Any(r => r.Method == HttpMethod.Delete));
         }
 
         // ---- 5xx is surfaced (the existing retry-with-backoff wrapper lives upstream) ----
@@ -272,9 +213,9 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
             Assert.AreEqual(DateTimeOffset.FromUnixTimeSeconds(resetEpoch), ex.RateLimit!.Reset);
         }
 
-        // ---- Orchestrator end-to-end: GET current → diff → POST adds, DELETE removes ----
+        // ---- Orchestrator end-to-end: GET current → diff → PATCH adds, PATCH removes ----
         [TestMethod]
-        public async Task ReconcileEnabledConnections_MixedAddAndRemove_IssuesPostAndDelete()
+        public async Task ReconcileEnabledConnections_MixedAddAndRemove_IssuesPatchPerAffectedConnection()
         {
             const string KeepId = "con_keep";
             const string AddId = "con_add";
@@ -287,9 +228,7 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
                     {
                         Content = new StringContent(BuildConnectionsBody(KeepId, RemoveId))
                     };
-                if (req.Method == HttpMethod.Post)
-                    return new HttpResponseMessage(HttpStatusCode.Created);
-                if (req.Method == HttpMethod.Delete)
+                if (req.Method == HttpMethod.Patch)
                     return new HttpResponseMessage(HttpStatusCode.NoContent);
                 return new HttpResponseMessage(HttpStatusCode.InternalServerError);
             });
@@ -303,20 +242,26 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
                 },
                 defaultNamespace: "default", CancellationToken.None);
 
-            var post = handler.Requests.SingleOrDefault(r => r.Method == HttpMethod.Post);
-            var delete = handler.Requests.SingleOrDefault(r => r.Method == HttpMethod.Delete);
+            var patches = handler.Requests.Where(r => r.Method == HttpMethod.Patch).ToList();
+            Assert.AreEqual(2, patches.Count, "Expected one PATCH per affected connection (add + remove).");
 
-            Assert.IsNotNull(post, "Expected a POST for the added connection");
-            Assert.IsTrue(post!.RequestUri!.AbsolutePath.EndsWith($"/connections/{AddId}/clients"));
-            StringAssert.Contains(post.Body, $"\"client_id\":\"{ClientId}\"");
+            var addPatch = patches.SingleOrDefault(p =>
+                p.RequestUri!.AbsolutePath.EndsWith($"/connections/{AddId}/clients"));
+            Assert.IsNotNull(addPatch, "Expected a PATCH for the added connection");
+            StringAssert.Contains(addPatch!.Body, $"\"client_id\":\"{ClientId}\"");
+            StringAssert.Contains(addPatch.Body, "\"status\":true");
 
-            Assert.IsNotNull(delete, "Expected a DELETE for the removed connection");
-            Assert.IsTrue(delete!.RequestUri!.AbsolutePath.EndsWith($"/connections/{RemoveId}/clients/{ClientId}"));
+            var removePatch = patches.SingleOrDefault(p =>
+                p.RequestUri!.AbsolutePath.EndsWith($"/connections/{RemoveId}/clients"));
+            Assert.IsNotNull(removePatch, "Expected a PATCH for the removed connection");
+            StringAssert.Contains(removePatch!.Body, $"\"client_id\":\"{ClientId}\"");
+            StringAssert.Contains(removePatch.Body, "\"status\":false");
 
             // Untouched 'keep' connection must not be re-issued.
             Assert.IsFalse(handler.Requests.Any(r =>
-                r.Method != HttpMethod.Get &&
-                r.RequestUri!.AbsolutePath.Contains($"/connections/{KeepId}/")));
+                r.Method == HttpMethod.Patch &&
+                r.RequestUri!.AbsolutePath.EndsWith($"/connections/{KeepId}/clients")),
+                "The unchanged 'keep' connection should not be PATCHed.");
         }
 
         // Single helper for assembling the GET /clients/{id}/connections response body so the

--- a/src/Alethic.Auth0.Operator.Tests/Controllers/V1ClientControllerEnabledConnectionsTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Controllers/V1ClientControllerEnabledConnectionsTests.cs
@@ -1,0 +1,324 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Alethic.Auth0.Operator.Controllers;
+using Alethic.Auth0.Operator.Options;
+using Alethic.Auth0.Operator.Services;
+using KubeOps.Abstractions.Queue;
+using KubeOps.KubernetesClient;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Alethic.Auth0.Operator.Tests.Controllers
+{
+    /// <summary>
+    /// Coverage for <see cref="V1ClientController"/>'s per-client connection enable/disable
+    /// helpers, which replaced the deprecated <c>enabled_clients</c> PATCH flow on
+    /// <c>PATCH /api/v2/connections/{id}</c>.
+    ///
+    /// New endpoints exercised here:
+    /// - <c>POST /api/v2/connections/{connectionId}/clients</c> with body <c>{"client_id":"..."}</c>
+    /// - <c>DELETE /api/v2/connections/{connectionId}/clients/{clientId}</c>
+    ///
+    /// The controller's <c>IHttpClientFactory</c> dependency lets us inject a fake
+    /// <see cref="HttpMessageHandler"/> and assert on the exact request stream.
+    /// </summary>
+    [TestClass]
+    public class V1ClientControllerEnabledConnectionsTests
+    {
+        private const string TenantBaseUri = "https://example.us.auth0.com/api/v2/";
+        private const string ConnectionId = "con_test123";
+        private const string ClientId = "abc_clientid";
+        private const string OtherClientId = "xyz_other";
+
+        // ---- Golden path: enable issues POST and 2xx clears ----
+
+        [TestMethod]
+        public async Task EnableClientOnConnection_ClientNotYetEnabled_IssuesPostAndSucceeds()
+        {
+            var handler = new RecordingHandler((req, _) =>
+                new HttpResponseMessage(HttpStatusCode.Created) { Content = new StringContent("") });
+            var controller = BuildController(handler);
+            var tenant = new FakeTenantApiAccess();
+
+            await controller.EnableClientOnConnectionAsync(tenant, ConnectionId, ClientId, CancellationToken.None);
+
+            Assert.AreEqual(1, handler.Requests.Count);
+            var req = handler.Requests[0];
+            Assert.AreEqual(HttpMethod.Post, req.Method);
+            Assert.AreEqual(new Uri(new Uri(TenantBaseUri), $"connections/{ConnectionId}/clients"),
+                req.RequestUri);
+            StringAssert.Contains(req.Body, $"\"client_id\":\"{ClientId}\"");
+        }
+
+        // ---- Benign 409 ("already enabled") swallowed as no-op ----
+
+        [TestMethod]
+        public async Task EnableClientOnConnection_AlreadyEnabled_BenignErrorCode_IsNoOp()
+        {
+            var body = "{\"statusCode\":409,\"error\":\"Conflict\",\"message\":\"Client already enabled\"," +
+                       "\"errorCode\":\"connection_client_already_enabled\"}";
+            var handler = new RecordingHandler((_, __) => new HttpResponseMessage(HttpStatusCode.Conflict)
+                { Content = new StringContent(body) });
+            var controller = BuildController(handler);
+
+            await controller.EnableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
+                CancellationToken.None);
+
+            Assert.AreEqual(1, handler.Requests.Count);
+        }
+
+        // ---- Non-benign 409 (e.g. validation) surfaces as an exception ----
+
+        [TestMethod]
+        public async Task EnableClientOnConnection_409WithUnrelatedErrorCode_Throws()
+        {
+            var body = "{\"statusCode\":409,\"error\":\"Conflict\",\"message\":\"Validation failed\"," +
+                       "\"errorCode\":\"validation_error\"}";
+            var handler = new RecordingHandler((_, __) => new HttpResponseMessage(HttpStatusCode.Conflict)
+                { Content = new StringContent(body) });
+            var controller = BuildController(handler);
+
+            await Assert.ThrowsExceptionAsync<HttpRequestException>(() =>
+                controller.EnableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
+                    CancellationToken.None));
+        }
+
+        // ---- Golden path: disable issues DELETE and 204 clears ----
+
+        [TestMethod]
+        public async Task DisableClientOnConnection_ClientEnabled_IssuesDeleteAndSucceeds()
+        {
+            var handler = new RecordingHandler((_, __) =>
+                new HttpResponseMessage(HttpStatusCode.NoContent));
+            var controller = BuildController(handler);
+
+            await controller.DisableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
+                CancellationToken.None);
+
+            Assert.AreEqual(1, handler.Requests.Count);
+            var req = handler.Requests[0];
+            Assert.AreEqual(HttpMethod.Delete, req.Method);
+            Assert.AreEqual(new Uri(new Uri(TenantBaseUri), $"connections/{ConnectionId}/clients/{ClientId}"),
+                req.RequestUri);
+        }
+
+        // ---- Benign 404 ("not currently enabled") swallowed as no-op ----
+
+        [TestMethod]
+        public async Task DisableClientOnConnection_NotEnabled_BenignErrorCode_IsNoOp()
+        {
+            var body = "{\"statusCode\":404,\"error\":\"Not Found\",\"message\":\"Client not enabled\"," +
+                       "\"errorCode\":\"connection_client_not_found\"}";
+            var handler = new RecordingHandler((_, __) => new HttpResponseMessage(HttpStatusCode.NotFound)
+                { Content = new StringContent(body) });
+            var controller = BuildController(handler);
+
+            await controller.DisableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
+                CancellationToken.None);
+
+            Assert.AreEqual(1, handler.Requests.Count);
+        }
+
+        // ---- Non-benign 404 (wrong connection_id) surfaces ----
+
+        [TestMethod]
+        public async Task DisableClientOnConnection_404WithUnrelatedErrorCode_Throws()
+        {
+            var body = "{\"statusCode\":404,\"error\":\"Not Found\",\"message\":\"Connection not found\"," +
+                       "\"errorCode\":\"connection_not_found\"}";
+            var handler = new RecordingHandler((_, __) => new HttpResponseMessage(HttpStatusCode.NotFound)
+                { Content = new StringContent(body) });
+            var controller = BuildController(handler);
+
+            await Assert.ThrowsExceptionAsync<HttpRequestException>(() =>
+                controller.DisableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
+                    CancellationToken.None));
+        }
+
+        // ---- 401 triggers token regeneration and a single retry ----
+
+        [TestMethod]
+        public async Task EnableClientOnConnection_401Once_RegeneratesTokenAndRetriesOnce()
+        {
+            var calls = 0;
+            var handler = new RecordingHandler((_, __) =>
+            {
+                calls++;
+                return calls == 1
+                    ? new HttpResponseMessage(HttpStatusCode.Unauthorized) { Content = new StringContent("") }
+                    : new HttpResponseMessage(HttpStatusCode.Created) { Content = new StringContent("") };
+            });
+            var controller = BuildController(handler);
+            var tenant = new FakeTenantApiAccess { TokenSequence = new[] { "tok-1", "tok-2" } };
+
+            await controller.EnableClientOnConnectionAsync(tenant, ConnectionId, ClientId, CancellationToken.None);
+
+            Assert.AreEqual(2, handler.Requests.Count, "Should retry once after 401");
+            Assert.AreEqual("tok-1", handler.Requests[0].Authorization);
+            Assert.AreEqual("tok-2", handler.Requests[1].Authorization);
+        }
+
+        // ---- Concurrent add + remove of same (connection, client): both calls happen, atomic per call ----
+
+        [TestMethod]
+        public async Task AddAndRemove_SamePair_BothCallsIssuedDeterministically()
+        {
+            var handler = new RecordingHandler((req, _) =>
+                new HttpResponseMessage(req.Method == HttpMethod.Post ? HttpStatusCode.Created : HttpStatusCode.NoContent));
+            var controller = BuildController(handler);
+            var tenant = new FakeTenantApiAccess();
+
+            // No mutex any more — fire concurrently and assert both calls completed.
+            await Task.WhenAll(
+                controller.EnableClientOnConnectionAsync(tenant, ConnectionId, ClientId, CancellationToken.None),
+                controller.DisableClientOnConnectionAsync(tenant, ConnectionId, ClientId, CancellationToken.None));
+
+            Assert.AreEqual(2, handler.Requests.Count);
+            Assert.IsTrue(handler.Requests.Any(r => r.Method == HttpMethod.Post));
+            Assert.IsTrue(handler.Requests.Any(r => r.Method == HttpMethod.Delete));
+        }
+
+        // ---- 5xx is surfaced (the existing retry-with-backoff wrapper lives upstream) ----
+
+        [TestMethod]
+        public async Task EnableClientOnConnection_5xx_Throws()
+        {
+            var handler = new RecordingHandler((_, __) => new HttpResponseMessage(HttpStatusCode.InternalServerError)
+                { Content = new StringContent("{\"statusCode\":500,\"error\":\"server\"}") });
+            var controller = BuildController(handler);
+
+            await Assert.ThrowsExceptionAsync<HttpRequestException>(() =>
+                controller.EnableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
+                    CancellationToken.None));
+        }
+
+        // ---- 429 is surfaced (same upstream retry wrapper reacts to it) ----
+
+        [TestMethod]
+        public async Task DisableClientOnConnection_429_Throws()
+        {
+            var handler = new RecordingHandler((_, __) => new HttpResponseMessage((HttpStatusCode)429)
+                { Content = new StringContent("{\"statusCode\":429,\"error\":\"Too Many Requests\"}") });
+            var controller = BuildController(handler);
+
+            await Assert.ThrowsExceptionAsync<HttpRequestException>(() =>
+                controller.DisableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
+                    CancellationToken.None));
+        }
+
+        // ---- "Out of band" Auth0 add: an existing enabled client → next reconcile issues DELETE ----
+        //
+        // This test models the controller's external behavior: after Auth0 already has the client
+        // enabled, calling the disable helper issues a single DELETE. The decision to *issue* the
+        // DELETE comes from the reconcile loop's diff against GetClientConnectionsAsync; that piece
+        // is covered by the integration of these primitives at the ApplyConnectionChanges call site.
+        [TestMethod]
+        public async Task DisableClientOnConnection_OutOfBandAuth0Add_IssuesDelete()
+        {
+            var handler = new RecordingHandler((_, __) => new HttpResponseMessage(HttpStatusCode.NoContent));
+            var controller = BuildController(handler);
+
+            await controller.DisableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, OtherClientId,
+                CancellationToken.None);
+
+            Assert.AreEqual(1, handler.Requests.Count);
+            Assert.AreEqual(HttpMethod.Delete, handler.Requests[0].Method);
+            Assert.IsTrue(handler.Requests[0].RequestUri!.AbsolutePath.EndsWith($"/clients/{OtherClientId}"));
+        }
+
+        // ---- Policy gating: if no POST/DELETE is invoked, no HTTP call hits the wire ----
+        //
+        // The new helpers are pure wire-level primitives. The policy gating decision (whether to call
+        // them at all) lives in V1ClientController's reconcile flow, which only enters
+        // ApplyConnectionChanges when an update is permitted. This test pins the contract: no helper
+        // invocation == no HTTP request, so policy-gated callers can confidently skip the helpers.
+        [TestMethod]
+        public void PolicyGating_NoHelperInvocation_NoHttpCalls()
+        {
+            var handler = new RecordingHandler((_, __) => new HttpResponseMessage(HttpStatusCode.OK));
+            _ = BuildController(handler);
+
+            Assert.AreEqual(0, handler.Requests.Count,
+                "Constructing the controller must not issue any HTTP calls; policy-gated callers that skip the helpers cause no wire traffic.");
+        }
+
+        // ---- helpers ----
+
+        private static V1ClientController BuildController(HttpMessageHandler handler)
+        {
+            var factory = new SingleHandlerHttpClientFactory(handler);
+            // DispatchProxy gives us a runtime stub for IKubernetesClient — the helpers under
+            // test never call into it, so any invocation will throw via the proxy's interceptor.
+            var kube = System.Reflection.DispatchProxy.Create<IKubernetesClient, ThrowingKubeProxy>();
+            return new V1ClientController(
+                kube: kube,
+                requeue: (EntityRequeue<Alethic.Auth0.Operator.Models.V1Client>)((entity, ts) => { }),
+                cache: new MemoryCache(new MemoryCacheOptions()),
+                logger: NullLogger<V1ClientController>.Instance,
+                options: Microsoft.Extensions.Options.Options.Create(new OperatorOptions()),
+                httpClientFactory: factory);
+        }
+
+        public class ThrowingKubeProxy : System.Reflection.DispatchProxy
+        {
+            protected override object? Invoke(System.Reflection.MethodInfo? targetMethod, object?[]? args) =>
+                throw new InvalidOperationException(
+                    $"IKubernetesClient.{targetMethod?.Name} was unexpectedly invoked by the helpers under test.");
+        }
+
+        private sealed class SingleHandlerHttpClientFactory : IHttpClientFactory
+        {
+            private readonly HttpMessageHandler _handler;
+            public SingleHandlerHttpClientFactory(HttpMessageHandler handler) => _handler = handler;
+            public HttpClient CreateClient(string name) => new HttpClient(_handler, disposeHandler: false);
+        }
+
+        private sealed class FakeTenantApiAccess : ITenantApiAccess
+        {
+            public string[] TokenSequence { get; set; } = new[] { "fake-token" };
+            private int _index;
+            public Uri BaseUri => new Uri(TenantBaseUri);
+            public Task<string> GetAccessTokenAsync(CancellationToken cancellationToken = default)
+            {
+                var tok = TokenSequence[Math.Min(_index, TokenSequence.Length - 1)];
+                _index++;
+                return Task.FromResult(tok);
+            }
+        }
+
+        private sealed class RecordingHandler : HttpMessageHandler
+        {
+            private readonly Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> _responder;
+            public List<RecordedRequest> Requests { get; } = new();
+
+            public RecordingHandler(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> responder)
+            {
+                _responder = responder;
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                var body = request.Content is null
+                    ? string.Empty
+                    : await request.Content.ReadAsStringAsync(cancellationToken);
+                Requests.Add(new RecordedRequest(
+                    request.Method,
+                    request.RequestUri,
+                    request.Headers.Authorization?.Parameter,
+                    body));
+                return _responder(request, cancellationToken);
+            }
+        }
+
+        private sealed record RecordedRequest(HttpMethod Method, Uri? RequestUri, string? Authorization, string Body);
+
+    }
+}

--- a/src/Alethic.Auth0.Operator.Tests/Controllers/V1ControllerRetryAndRequeueTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Controllers/V1ControllerRetryAndRequeueTests.cs
@@ -321,7 +321,7 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
             protected override Task<string> Create(global::Auth0.ManagementApi.IManagementApiClient api, ClientConf conf, string defaultNamespace, CancellationToken cancellationToken)
                 => Task.FromResult(string.Empty);
 
-            protected override Task Update(global::Auth0.ManagementApi.IManagementApiClient api, string id, System.Collections.Hashtable? last, ClientConf conf, IReadOnlyList<DriftField> driftFields, string defaultNamespace, Alethic.Auth0.Operator.Services.ITenantApiAccess tenantApiAccess, DriftLogContext driftContext, CancellationToken cancellationToken)
+            protected override Task Update(global::Auth0.ManagementApi.IManagementApiClient api, string id, System.Collections.Hashtable? last, ClientConf conf, List<string> driftingFields, string defaultNamespace, Alethic.Auth0.Operator.Services.ITenantApiAccess tenantApiAccess, CancellationToken cancellationToken)
                 => Task.CompletedTask;
 
             protected override Task Delete(global::Auth0.ManagementApi.IManagementApiClient api, string id, CancellationToken cancellationToken)

--- a/src/Alethic.Auth0.Operator.Tests/Controllers/V1ControllerRetryAndRequeueTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Controllers/V1ControllerRetryAndRequeueTests.cs
@@ -1,0 +1,355 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Alethic.Auth0.Operator.Controllers;
+using Alethic.Auth0.Operator.Core.Models.Client;
+using Alethic.Auth0.Operator.Models;
+using Alethic.Auth0.Operator.Options;
+
+using Auth0.Core.Exceptions;
+
+using k8s.Autorest;
+using k8s.Models;
+
+using KubeOps.Abstractions.Queue;
+using KubeOps.KubernetesClient;
+
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Moq;
+
+namespace Alethic.Auth0.Operator.Tests.Controllers
+{
+    /// <summary>
+    /// Coverage for the hot-fix that targets the status-write 409 race + always-requeue
+    /// behaviour added in <c>V1TenantEntityController.UpdateKubernetesStatus</c> and
+    /// <c>V1Controller.ReconcileAsync</c>. See:
+    /// <list type="bullet">
+    /// <item>findings/2026-05-18-status-write-409-loses-side-effect-and-stalls-reconcile.md</item>
+    /// <item>plans/2026-05-18__11-00-03 - auth0-operator - status-write-409-and-always-requeue-hotfix.md</item>
+    /// </list>
+    /// </summary>
+    [TestClass]
+    public class V1ControllerRetryAndRequeueTests
+    {
+        // ---- Common helpers ----
+
+        private static V1Client MakeClient(string name = "c1", string ns = "default", string? resourceVersion = "rv-1")
+        {
+            return new V1Client
+            {
+                Metadata = new V1ObjectMeta
+                {
+                    Name = name,
+                    NamespaceProperty = ns,
+                    ResourceVersion = resourceVersion,
+                    Annotations = new Dictionary<string, string>(),
+                },
+                Spec = new V1Client.SpecDef { Conf = new ClientConf() },
+                Status = new V1Client.StatusDef(),
+            };
+        }
+
+        private static HttpOperationException Make409() =>
+            new HttpOperationException("conflict")
+            {
+                Response = new HttpResponseMessageWrapper(
+                    new HttpResponseMessage(HttpStatusCode.Conflict), "{}"),
+            };
+
+        // ============================================================================
+        // 1. UpdateKubernetesStatus retries on 409 and succeeds — exercises the helper
+        //    via a thin test controller derived from V1Controller<V1Client, ...>.
+        // ============================================================================
+
+        [TestMethod]
+        public async Task UpdateKubernetesStatus_Retries_On_409_And_Succeeds()
+        {
+            var entity = MakeClient(resourceVersion: "rv-stale");
+            var refetched = MakeClient(resourceVersion: "rv-fresh");
+
+            V1Client? capturedSecondArg = null;
+            var kube = new Mock<IKubernetesClient>(MockBehavior.Strict);
+            // Hand-rolled sequence: 1st call throws 409, 2nd call captures + succeeds.
+            // Moq's SetupSequence(...).Returns(...) doesn't expose a lambda overload that
+            // captures the invocation arguments, so we drive the sequence via Callback.
+            var callCount = 0;
+            kube.Setup(k => k.UpdateStatusAsync(It.IsAny<V1Client>(), It.IsAny<CancellationToken>()))
+                .Returns((V1Client e, CancellationToken _) =>
+                {
+                    callCount++;
+                    if (callCount == 1)
+                        throw Make409();
+                    capturedSecondArg = e;
+                    return Task.FromResult(e);
+                });
+            kube.Setup(k => k.GetAsync<V1Client>(entity.Name(), entity.Namespace(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(refetched);
+
+            var controller = new TestController(kube.Object, requeue: (_, __) => { });
+            await controller.InvokeUpdateKubernetesStatusAsync(entity, "test", CancellationToken.None);
+
+            // M1: the second invocation must receive the SAME local entity reference the
+            // caller passed in (not the refetched object). The retry is "carry resourceVersion
+            // forward onto local"; the caller's desired Status object is preserved by reference.
+            Assert.IsNotNull(capturedSecondArg);
+            Assert.AreSame(entity, capturedSecondArg,
+                "Retry must reuse the caller's local entity — never substitute the refetched object.");
+            Assert.AreEqual("rv-fresh", capturedSecondArg!.Metadata!.ResourceVersion,
+                "Retry must advance the local entity's resourceVersion from the refetched object.");
+            Assert.AreSame(entity.Status, capturedSecondArg.Status,
+                "Retry must preserve the caller's Status object reference.");
+            kube.Verify(k => k.UpdateStatusAsync(It.IsAny<V1Client>(), It.IsAny<CancellationToken>()),
+                Times.Exactly(2));
+        }
+
+        // ============================================================================
+        // 2. UpdateKubernetesStatus exhausts retries → throws original 409.
+        // ============================================================================
+
+        [TestMethod]
+        public async Task UpdateKubernetesStatus_Throws_After_Retry_Exhaustion()
+        {
+            var entity = MakeClient();
+            var refetched = MakeClient(resourceVersion: "rv-fresh");
+
+            var kube = new Mock<IKubernetesClient>(MockBehavior.Strict);
+            kube.Setup(k => k.UpdateStatusAsync(It.IsAny<V1Client>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(Make409());
+            kube.Setup(k => k.GetAsync<V1Client>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(refetched);
+
+            var controller = new TestController(kube.Object, requeue: (_, __) => { });
+
+            var ex = await Assert.ThrowsExceptionAsync<HttpOperationException>(() =>
+                controller.InvokeUpdateKubernetesStatusAsync(entity, "test", CancellationToken.None));
+
+            Assert.AreEqual(HttpStatusCode.Conflict, ex.Response?.StatusCode);
+
+            // 1 initial attempt + 3 retries = 4 total UpdateStatusAsync calls.
+            kube.Verify(k => k.UpdateStatusAsync(It.IsAny<V1Client>(), It.IsAny<CancellationToken>()),
+                Times.Exactly(4));
+        }
+
+        // ============================================================================
+        // 3. ReconcileAsync schedules requeue on generic Exception.
+        // ============================================================================
+
+        [TestMethod]
+        public async Task ReconcileAsync_Schedules_Requeue_On_Generic_Exception()
+        {
+            var entity = MakeClient();
+            var requeueCalls = new List<(V1Client entity, TimeSpan delay)>();
+
+            var kube = new Mock<IKubernetesClient>(MockBehavior.Loose);
+            var controller = new TestController(
+                kube.Object,
+                requeue: (e, d) => requeueCalls.Add((e, d)),
+                reconcileImpl: (_, __) => throw new InvalidOperationException("simulated transient downstream error"));
+
+            await controller.ReconcileAsync(entity, CancellationToken.None);
+
+            Assert.AreEqual(1, requeueCalls.Count, "ReconcileAsync must always schedule a requeue on unexpected exceptions.");
+            Assert.AreSame(entity, requeueCalls[0].entity);
+            // M3: tighten delay assertion to [22.5s, 37.5s] (30s ±25% jitter).
+            var d = requeueCalls[0].delay;
+            Assert.IsTrue(d >= TimeSpan.FromSeconds(22.5) && d <= TimeSpan.FromSeconds(37.5),
+                $"Requeue delay must be 30s ±25% jitter; got {d}.");
+        }
+
+        // ============================================================================
+        // 4. ReconcileAsync schedules requeue on ErrorApiException (Auth0 API failure).
+        // ============================================================================
+
+        [TestMethod]
+        public async Task ReconcileAsync_Schedules_Requeue_On_ErrorApiException()
+        {
+            var entity = MakeClient();
+            var requeueCalls = new List<(V1Client entity, TimeSpan delay)>();
+
+            var kube = new Mock<IKubernetesClient>(MockBehavior.Loose);
+            var controller = new TestController(
+                kube.Object,
+                requeue: (e, d) => requeueCalls.Add((e, d)),
+                reconcileImpl: (_, __) => throw new ErrorApiException(
+                    HttpStatusCode.BadGateway,
+                    new ApiError { Message = "simulated upstream failure" }));
+
+            await controller.ReconcileAsync(entity, CancellationToken.None);
+
+            Assert.AreEqual(1, requeueCalls.Count,
+                "ReconcileAsync must schedule a requeue on Auth0 ErrorApiException (prior impl logged and fell through).");
+            var d = requeueCalls[0].delay;
+            Assert.IsTrue(d >= TimeSpan.FromSeconds(22.5) && d <= TimeSpan.FromSeconds(37.5),
+                $"Requeue delay must be 30s ±25% jitter; got {d}.");
+        }
+
+        // ============================================================================
+        // M2: end-to-end status-write retry-exhaustion → requeue (the original incident).
+        // ============================================================================
+
+        [TestMethod]
+        public async Task ReconcileAsync_Schedules_Requeue_On_Status_Write_Retry_Exhaustion()
+        {
+            var entity = MakeClient();
+            var requeueCalls = new List<(V1Client entity, TimeSpan delay)>();
+
+            var kube = new Mock<IKubernetesClient>(MockBehavior.Loose);
+            // Status writes consistently 409.
+            kube.Setup(k => k.UpdateStatusAsync(It.IsAny<V1Client>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(Make409());
+            kube.Setup(k => k.GetAsync<V1Client>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(MakeClient(resourceVersion: "rv-fresh"));
+
+            // Reconcile path: call UpdateKubernetesStatus directly to simulate the
+            // FinalizeReconciliation → UpdateKubernetesStatus path that triggered the live
+            // incident. The retry helper exhausts (4 attempts) and re-throws into the
+            // outer catch chain.
+            var controller = new TestController(
+                kube.Object,
+                requeue: (e, d) => requeueCalls.Add((e, d)),
+                reconcileImpl: (self, ent) => self.InvokeUpdateKubernetesStatusForReconcile(ent));
+
+            await controller.ReconcileAsync(entity, CancellationToken.None);
+
+            Assert.AreEqual(1, requeueCalls.Count,
+                "Retry exhaustion must funnel through the outer catch and produce exactly one Requeue.");
+            var d = requeueCalls[0].delay;
+            Assert.IsTrue(d >= TimeSpan.FromSeconds(22.5) && d <= TimeSpan.FromSeconds(37.5),
+                $"Requeue delay must be 30s ±25% jitter; got {d}.");
+
+            // And confirm the inner helper actually ran the full 4-attempt cycle.
+            kube.Verify(k => k.UpdateStatusAsync(It.IsAny<V1Client>(), It.IsAny<CancellationToken>()),
+                Times.Exactly(4));
+        }
+
+        // ============================================================================
+        // L2: ComputeKubeConflictRetryDelayMs clamps gracefully when attempt > table size.
+        // ============================================================================
+
+        [TestMethod]
+        public void ComputeKubeConflictRetryDelayMs_ClampsWhenAttemptExceedsTable()
+        {
+            // Table has 3 entries (100, 400, 1600 ms). Any attempt > 3 must clamp to the
+            // last entry and stay within ±25% jitter — i.e. [1200, 2000] ms.
+            for (int attempt = 4; attempt <= 10; attempt++)
+            {
+                var d = ReflectionAccessor.ComputeKubeConflictRetryDelayMs(attempt);
+                Assert.IsTrue(d >= 1200 && d <= 2000,
+                    $"attempt={attempt}: expected delay clamped to ~1600ms ±25%; got {d}ms.");
+            }
+
+            // Attempt <= 0 must coerce to attempt=1 (~100ms ±25% → [75, 125] ms).
+            for (int attempt = -2; attempt <= 1; attempt++)
+            {
+                var d = ReflectionAccessor.ComputeKubeConflictRetryDelayMs(attempt);
+                Assert.IsTrue(d >= 75 && d <= 125,
+                    $"attempt={attempt}: expected delay coerced to attempt=1 (~100ms ±25%); got {d}ms.");
+            }
+        }
+
+        // ---- Test scaffolding ----
+
+        /// <summary>
+        /// Reflection bridge to the internal static <c>ComputeKubeConflictRetryDelayMs</c>
+        /// on the open-generic <c>V1TenantEntityController&lt;,,,&gt;</c>. Walks the
+        /// concrete <c>TestController</c>'s base type chain to find the closed generic
+        /// that exposes the method.
+        /// </summary>
+        private static class ReflectionAccessor
+        {
+            private static readonly System.Reflection.MethodInfo _method =
+                typeof(TestController).BaseType! // V1TenantEntityController<V1Client,...>
+                    .GetMethod("ComputeKubeConflictRetryDelayMs",
+                        System.Reflection.BindingFlags.Static |
+                        System.Reflection.BindingFlags.NonPublic |
+                        System.Reflection.BindingFlags.Public)
+                ?? throw new InvalidOperationException("ComputeKubeConflictRetryDelayMs not found");
+
+            public static int ComputeKubeConflictRetryDelayMs(int attempt) =>
+                (int)_method.Invoke(null, new object[] { attempt })!;
+        }
+
+        /// <summary>
+        /// Thin test-only controller derived from <see cref="V1TenantEntityController{,,,}"/>
+        /// closed over <see cref="V1Client"/>. Lets tests:
+        /// <list type="bullet">
+        /// <item>invoke the protected <c>UpdateKubernetesStatus</c> helper directly;</item>
+        /// <item>override the abstract <c>Reconcile</c> method with a per-test delegate so we
+        /// can drive the catch chain in <c>V1Controller.ReconcileAsync</c> deterministically.</item>
+        /// </list>
+        /// </summary>
+        private sealed class TestController : V1TenantEntityController<V1Client, V1Client.SpecDef, V1Client.StatusDef, ClientConf>
+        {
+            private readonly Func<TestController, V1Client, Task>? _reconcileImpl;
+
+            public TestController(
+                IKubernetesClient kube,
+                EntityRequeue<V1Client> requeue,
+                Func<TestController, V1Client, Task>? reconcileImpl = null)
+                : base(
+                    kube,
+                    requeue,
+                    new MemoryCache(new MemoryCacheOptions()),
+                    NullLogger<TestController>.Instance,
+                    global::Microsoft.Extensions.Options.Options.Create(new OperatorOptions()))
+            {
+                _reconcileImpl = reconcileImpl;
+            }
+
+            protected override string EntityTypeName => "A0Client";
+
+            // -- Abstract pass-throughs (test never exercises Auth0 path). --
+
+            protected override Task<System.Collections.Hashtable?> Get(global::Auth0.ManagementApi.IManagementApiClient api, string id, string defaultNamespace, CancellationToken cancellationToken)
+                => Task.FromResult<System.Collections.Hashtable?>(null);
+
+            protected override Task<string?> Find(global::Auth0.ManagementApi.IManagementApiClient api, V1Client entity, V1Client.SpecDef spec, string defaultNamespace, CancellationToken cancellationToken)
+                => Task.FromResult<string?>(null);
+
+            protected override string? ValidateCreate(ClientConf conf) => null;
+
+            protected override Task<string> Create(global::Auth0.ManagementApi.IManagementApiClient api, ClientConf conf, string defaultNamespace, CancellationToken cancellationToken)
+                => Task.FromResult(string.Empty);
+
+            protected override Task Update(global::Auth0.ManagementApi.IManagementApiClient api, string id, System.Collections.Hashtable? last, ClientConf conf, IReadOnlyList<DriftField> driftFields, string defaultNamespace, Alethic.Auth0.Operator.Services.ITenantApiAccess tenantApiAccess, DriftLogContext driftContext, CancellationToken cancellationToken)
+                => Task.CompletedTask;
+
+            protected override Task Delete(global::Auth0.ManagementApi.IManagementApiClient api, string id, CancellationToken cancellationToken)
+                => Task.CompletedTask;
+
+            // -- Reconcile override: by default no-op; tests inject custom behaviour. --
+
+            protected override async Task<(bool needsRequeue, V1Client updatedEntity)> Reconcile(V1Client entity, CancellationToken cancellationToken)
+            {
+                if (_reconcileImpl is not null)
+                    await _reconcileImpl(this, entity);
+                return (false, entity);
+            }
+
+            // -- Test hooks. --
+
+            public Task<V1Client> InvokeUpdateKubernetesStatusAsync(V1Client entity, string operation, CancellationToken ct)
+                => UpdateKubernetesStatus(entity, operation, ct);
+
+            /// <summary>
+            /// Used by the end-to-end status-write-exhaustion test: simulates the production
+            /// FinalizeReconciliation path's call to UpdateKubernetesStatus from inside
+            /// the Reconcile method body.
+            /// </summary>
+            public async Task InvokeUpdateKubernetesStatusForReconcile(V1Client entity)
+            {
+                await UpdateKubernetesStatus(entity, "test_finalize_reconciliation", CancellationToken.None);
+            }
+        }
+    }
+}

--- a/src/Alethic.Auth0.Operator/Alethic.Auth0.Operator.csproj
+++ b/src/Alethic.Auth0.Operator/Alethic.Auth0.Operator.csproj
@@ -22,8 +22,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Auth0.AuthenticationApi" Version="7.40.0" />
-        <PackageReference Include="Auth0.ManagementApi" Version="7.40.0" />
+        <PackageReference Include="Auth0.AuthenticationApi" Version="7.46.0" />
+        <PackageReference Include="Auth0.ManagementApi" Version="7.46.0" />
         <PackageReference Include="KubeOps.Generator" Version="9.11.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Alethic.Auth0.Operator/Controllers/V1ClientController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1ClientController.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -40,24 +39,15 @@ namespace Alethic.Auth0.Operator.Controllers
         V1TenantEntityController<V1Client, V1Client.SpecDef, V1Client.StatusDef, ClientConf>,
         IEntityController<V1Client>
     {
-        readonly IMemoryCache _clientCache;
-        readonly IMemoryCache _connectionCache;
-        static readonly ConcurrentDictionary<string, SemaphoreSlim> _connectionUpdateMutexes = new();
+        readonly IMemoryCache _cache;
+        readonly IHttpClientFactory _httpClientFactory;
 
-        /// <summary>
-        /// Initializes a new instance.
-        /// </summary>
-        /// <param name="kube"></param>
-        /// <param name="requeue"></param>
-        /// <param name="cache"></param>
-        /// <param name="logger"></param>
-        /// <param name="options"></param>
         public V1ClientController(IKubernetesClient kube, EntityRequeue<V1Client> requeue, IMemoryCache cache,
-            ILogger<V1ClientController> logger, IOptions<OperatorOptions> options) :
+            ILogger<V1ClientController> logger, IOptions<OperatorOptions> options, IHttpClientFactory httpClientFactory) :
             base(kube, requeue, cache, logger, options)
         {
-            _clientCache = cache;
-            _connectionCache = cache;
+            _cache = cache;
+            _httpClientFactory = httpClientFactory;
         }
 
         /// <inheritdoc />
@@ -451,7 +441,7 @@ namespace Alethic.Auth0.Operator.Controllers
             var tenantDomain = await GetTenantDomainForCacheSalt(entity, cancellationToken);
 
             return await Auth0PaginationHelper.GetAllWithPaginationAsync(
-                _clientCache,
+                _cache,
                 Logger,
                 request,
                 api.Clients.GetAllAsync,
@@ -1182,23 +1172,6 @@ namespace Alethic.Auth0.Operator.Controllers
         }
 
         /// <summary>
-        /// Invalidates connection cache when a connection is modified.
-        /// </summary>
-        /// <param name="connectionId">Connection ID to invalidate</param>
-        void InvalidateConnectionCache(string connectionId)
-        {
-            var cacheKey = $"connection:{connectionId}";
-            _connectionCache.Remove(cacheKey);
-
-            Logger.LogInformationJson($"{EntityTypeName} invalidated connection cache: {connectionId}", new
-            {
-                entityTypeName = EntityTypeName,
-                connectionId,
-                operation = "cache_invalidate"
-            });
-        }
-
-        /// <summary>
         /// Gets enabled connections for a specific client using the direct Auth0 Management API endpoint
         /// Uses GET /api/v2/clients/{id}/connections which is more efficient than fetching all connections
         /// </summary>
@@ -1207,43 +1180,25 @@ namespace Alethic.Auth0.Operator.Controllers
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>List of connections enabled for the client</returns>
         private async Task<List<Connection>> GetClientConnectionsAsync(ITenantApiAccess tenantApiAccess,
-            string clientId, CancellationToken cancellationToken)
+            string clientId, string defaultNamespace, CancellationToken cancellationToken)
         {
             LogAuth0ApiCall($"Getting enabled connections for client: {clientId}", Auth0ApiCallType.Read,
-                "A0Connection", "client_direct", "unknown", "get_client_connections_direct");
-
-            var accessToken = await tenantApiAccess.GetAccessTokenAsync(cancellationToken);
+                "A0Connection", clientId, defaultNamespace, "get_client_connections_direct");
 
             // Use the direct Auth0 Management API endpoint: GET /api/v2/clients/{id}/connections
             var requestUri = new Uri(tenantApiAccess.BaseUri, $"clients/{clientId}/connections");
 
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-            httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            var response = await SendWithTokenAndRetryAsync(tenantApiAccess,
+                () => new HttpRequestMessage(HttpMethod.Get, requestUri),
+                operation: "get_client_connections",
+                cancellationToken);
 
-            try
+            if (!response.IsSuccessStatusCode)
+                await ThrowFromHttpFailureAsync(response, "get_client_connections", connectionId: "-",
+                    clientId, cancellationToken);
+
+            using (response)
             {
-                var response = await httpClient.GetAsync(requestUri, cancellationToken);
-
-                if (response.StatusCode == HttpStatusCode.Unauthorized)
-                {
-                    // Token might be expired, try to regenerate
-                    Logger.LogInformationJson(
-                        $"{EntityTypeName} received 401 Unauthorized, regenerating token for client {clientId}", new
-                        {
-                            entityTypeName = EntityTypeName,
-                            clientId,
-                            operation = "token_regeneration"
-                        });
-
-                    var newToken = await tenantApiAccess.GetAccessTokenAsync(cancellationToken);
-                    httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", newToken);
-
-                    response = await httpClient.GetAsync(requestUri, cancellationToken);
-                }
-
-                response.EnsureSuccessStatusCode();
-
                 var jsonContent = await response.Content.ReadAsStringAsync(cancellationToken);
                 var responseData =
                     Newtonsoft.Json.JsonConvert.DeserializeObject<ClientConnectionsResponse>(jsonContent);
@@ -1262,22 +1217,10 @@ namespace Alethic.Auth0.Operator.Controllers
 
                 return connections ?? new List<Connection>();
             }
-            catch (Exception ex)
-            {
-                Logger.LogErrorJson($"{EntityTypeName} failed to get connections for client {clientId}: {ex.Message}",
-                    new
-                    {
-                        entityTypeName = EntityTypeName,
-                        clientId,
-                        operation = "get_client_connections_direct",
-                        errorMessage = ex.Message
-                    }, ex);
-                throw;
-            }
         }
 
 
-        async Task ReconcileEnabledConnections(ITenantApiAccess tenantApiAccess, string clientId,
+        internal async Task ReconcileEnabledConnections(ITenantApiAccess tenantApiAccess, string clientId,
             V1ConnectionReference[]? enabledConnectionRefs, string defaultNamespace,
             CancellationToken cancellationToken)
         {
@@ -1288,9 +1231,8 @@ namespace Alethic.Auth0.Operator.Controllers
                         defaultNamespace, cancellationToken);
                 var (connectionsToAdd, connectionsToRemove) =
                     CalculateConnectionDifferences(currentConnectionIds, desiredConnectionIds);
-                var managementApiClient = await GetApiClientIfNeeded(tenantApiAccess, connectionsToAdd, connectionsToRemove);
 
-                await ApplyConnectionChanges(managementApiClient, clientId, connectionsToAdd, connectionsToRemove, cancellationToken);
+                await ApplyConnectionChanges(tenantApiAccess, clientId, connectionsToAdd, connectionsToRemove, cancellationToken);
                 LogReconciliationResult(clientId, currentConnectionIds.Count, connectionsToAdd.Count,
                     connectionsToRemove.Count);
             }
@@ -1313,7 +1255,7 @@ namespace Alethic.Auth0.Operator.Controllers
                 operation = "get_current_connections"
             });
 
-            var currentConnections = await GetClientConnectionsAsync(tenantApiAccess, clientId, cancellationToken);
+            var currentConnections = await GetClientConnectionsAsync(tenantApiAccess, clientId, defaultNamespace, cancellationToken);
             var currentConnectionIds =
                 currentConnections.Select(c => c.Id).Where(id => !string.IsNullOrEmpty(id)).ToHashSet();
 
@@ -1351,64 +1293,15 @@ namespace Alethic.Auth0.Operator.Controllers
             return (connectionsToAdd, connectionsToRemove);
         }
 
-        private async Task<IManagementApiClient?> GetApiClientIfNeeded(
-            ITenantApiAccess tenantApiAccess, List<string> connectionsToAdd, List<string> connectionsToRemove)
+        private async Task ApplyConnectionChanges(ITenantApiAccess tenantApiAccess, string clientId,
+            List<string> connectionsToAdd, List<string> connectionsToRemove,
+            CancellationToken cancellationToken)
         {
-            if (connectionsToAdd.Count == 0 && connectionsToRemove.Count == 0)
-                return null;
-
-            var accessToken = await tenantApiAccess.GetAccessTokenAsync(CancellationToken.None);
-            return new ManagementApiClient(accessToken, tenantApiAccess.BaseUri);
-        }
-
-        private async Task ApplyConnectionChanges(IManagementApiClient? managementApiClient, string clientId,
-            List<string> connectionsToAdd, List<string> connectionsToRemove, CancellationToken cancellationToken)
-        {
-            if (connectionsToAdd.Count > 0)
-            {
-                await AddConnectionsToClient(managementApiClient!, clientId, connectionsToAdd, cancellationToken);
-            }
-
-            if (connectionsToRemove.Count > 0)
-            {
-                await RemoveConnectionsFromClient(managementApiClient!, clientId, connectionsToRemove, cancellationToken);
-            }
-        }
-
-        private async Task AddConnectionsToClient(IManagementApiClient api, string clientId,
-            List<string> connectionsToAdd, CancellationToken cancellationToken)
-        {
-            Logger.LogInformationJson(
-                $"{EntityTypeName} adding {connectionsToAdd.Count} connections for client {clientId}", new
-                {
-                    entityTypeName = EntityTypeName,
-                    clientId,
-                    connectionsToAdd = connectionsToAdd.ToArray(),
-                    operation = "add_connections"
-                });
-
             foreach (var connectionId in connectionsToAdd)
-            {
-                await AddClientToConnection(api, connectionId, clientId, cancellationToken);
-            }
-        }
-
-        private async Task RemoveConnectionsFromClient(IManagementApiClient api, string clientId,
-            List<string> connectionsToRemove, CancellationToken cancellationToken)
-        {
-            Logger.LogInformationJson(
-                $"{EntityTypeName} removing {connectionsToRemove.Count} connections for client {clientId}", new
-                {
-                    entityTypeName = EntityTypeName,
-                    clientId,
-                    connectionsToRemove = connectionsToRemove.ToArray(),
-                    operation = "remove_connections"
-                });
+                await EnableClientOnConnectionAsync(tenantApiAccess, connectionId, clientId, cancellationToken);
 
             foreach (var connectionId in connectionsToRemove)
-            {
-                await RemoveClientFromConnection(api, connectionId, clientId, cancellationToken);
-            }
+                await DisableClientOnConnectionAsync(tenantApiAccess, connectionId, clientId, cancellationToken);
         }
 
         private void LogReconciliationResult(string clientId, int currentConnectionCount, int addedCount,
@@ -1441,247 +1334,150 @@ namespace Alethic.Auth0.Operator.Controllers
                 }, ex);
         }
 
-        /// <summary>
-        /// Adds a client ID to a connection's enabled_clients field with mutex protection.
-        /// </summary>
-        /// <param name="api">Auth0 Management API client</param>
-        /// <param name="connectionId">Connection ID to update</param>
-        /// <param name="clientId">Client ID to add to enabled_clients</param>
-        /// <param name="cancellationToken">Cancellation token</param>
-        async Task AddClientToConnection(IManagementApiClient api, string connectionId, string clientId,
-            CancellationToken cancellationToken)
+        /// <summary>POST /api/v2/connections/{connectionId}/clients — enables a single client on a connection.</summary>
+        internal Task EnableClientOnConnectionAsync(ITenantApiAccess tenantApiAccess, string connectionId,
+            string clientId, CancellationToken cancellationToken)
         {
-            var mutex = _connectionUpdateMutexes.GetOrAdd(connectionId, _ => new SemaphoreSlim(1, 1));
+            var requestUri = new Uri(tenantApiAccess.BaseUri, $"connections/{connectionId}/clients");
+            var payload = Newtonsoft.Json.JsonConvert.SerializeObject(new { client_id = clientId });
 
-            await mutex.WaitAsync(cancellationToken);
-            try
-            {
-                var currentConnection = await GetConnectionForUpdate(connectionId, clientId, "enabled_clients update",
-                    cancellationToken, api);
-                if (currentConnection is null) return;
-
-                var enabledClientIds = GetCurrentEnabledClients(connectionId, currentConnection);
-                if (IsClientAlreadyEnabled(connectionId, clientId, enabledClientIds)) return;
-
-                await UpdateConnectionWithAddedClient(api, connectionId, clientId, enabledClientIds, cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                LogConnectionUpdateError(connectionId, clientId, "update_enabled_clients", ex);
-                throw;
-            }
-            finally
-            {
-                mutex.Release();
-            }
+            return IssueAtomicMembershipChangeAsync(tenantApiAccess, connectionId, clientId,
+                () => new HttpRequestMessage(HttpMethod.Post, requestUri)
+                {
+                    Content = new StringContent(payload, Encoding.UTF8, "application/json")
+                },
+                operation: "enable_client_on_connection",
+                benign: BenignOutcome.AlreadyEnabled,
+                cancellationToken);
         }
 
-        private async Task<Connection?> GetConnectionForUpdate(string connectionId, string clientId, string operation,
-            CancellationToken cancellationToken, IManagementApiClient api)
+        /// <summary>DELETE /api/v2/connections/{connectionId}/clients/{clientId} — disables a single client on a connection.</summary>
+        internal Task DisableClientOnConnectionAsync(ITenantApiAccess tenantApiAccess, string connectionId,
+            string clientId, CancellationToken cancellationToken)
         {
-            Logger.LogInformationJson(
-                $"{EntityTypeName} reading current connection state before {operation}: {connectionId}", new
-                {
-                    entityTypeName = EntityTypeName,
-                    connectionId,
-                    clientId,
-                    operation = "preliminary_read"
-                });
+            var requestUri = new Uri(tenantApiAccess.BaseUri, $"connections/{connectionId}/clients/{clientId}");
 
-            LogAuth0ApiCall($"Getting Auth0 connection for {operation}: {connectionId}", Auth0ApiCallType.Read,
-                "A0Connection", connectionId, "unknown", "preliminary_connection_read");
-            var currentConnection = await api.Connections.GetAsync(connectionId, cancellationToken: cancellationToken);
-
-            if (currentConnection is null)
-            {
-                Logger.LogWarningJson($"{EntityTypeName} connection not found for {operation}: {connectionId}", new
-                {
-                    entityTypeName = EntityTypeName,
-                    connectionId,
-                    clientId,
-                    operation = "preliminary_read",
-                    status = "not_found"
-                });
-            }
-
-            return currentConnection;
-        }
-
-        private List<string> GetCurrentEnabledClients(string connectionId, Connection currentConnection)
-        {
-            LogAuth0ApiCall($"Getting Auth0 connection enabled clients: {connectionId}", Auth0ApiCallType.Read,
-                "A0Connection", connectionId, "unknown", "get_connection_enabled_clients");
-#pragma warning disable CS0618 // Type or member is obsolete
-            return currentConnection.EnabledClients?.ToList() ?? new List<string>();
-#pragma warning restore CS0618 // Type or member is obsolete
-        }
-
-        private bool IsClientAlreadyEnabled(string connectionId, string clientId, List<string> enabledClientIds)
-        {
-            if (enabledClientIds.Contains(clientId))
-            {
-                Logger.LogInformationJson(
-                    $"{EntityTypeName} client {clientId} already enabled for connection {connectionId}", new
-                    {
-                        entityTypeName = EntityTypeName,
-                        connectionId,
-                        clientId,
-                        operation = "enabled_clients_check",
-                        status = "already_enabled"
-                    });
-                return true;
-            }
-
-            return false;
-        }
-
-        private async Task UpdateConnectionWithAddedClient(IManagementApiClient api, string connectionId,
-            string clientId, List<string> enabledClientIds, CancellationToken cancellationToken)
-        {
-            enabledClientIds.Add(clientId);
-
-            var updateRequest = new ConnectionUpdateRequest
-            {
-#pragma warning disable CS0618 // Type or member is obsolete
-                EnabledClients = enabledClientIds.ToArray()
-#pragma warning restore CS0618 // Type or member is obsolete
-            };
-
-            Logger.LogWarningJson(
-                $"{EntityTypeName} updating connection {connectionId} to include client {clientId} in enabled_clients",
-                new
-                {
-                    entityTypeName = EntityTypeName,
-                    connectionId,
-                    clientId,
-                    operation = "update_enabled_clients"
-                });
-
-            LogAuth0ApiCall($"Updating Auth0 connection enabled_clients: connection ID = {connectionId}", Auth0ApiCallType.Write,
-                "A0Connection", connectionId, "unknown", "update_connection_enabled_clients");
-            await api.Connections.UpdateAsync(connectionId, updateRequest, cancellationToken);
-
-            InvalidateConnectionCache(connectionId);
-
-            Logger.LogWarningJson(
-                $"{EntityTypeName} successfully updated connection {connectionId} enabled_clients to include client {clientId}",
-                new
-                {
-                    entityTypeName = EntityTypeName,
-                    connectionId,
-                    clientId,
-                    operation = "update_enabled_clients",
-                    status = "success"
-                });
+            return IssueAtomicMembershipChangeAsync(tenantApiAccess, connectionId, clientId,
+                () => new HttpRequestMessage(HttpMethod.Delete, requestUri),
+                operation: "disable_client_on_connection",
+                benign: BenignOutcome.NotEnabled,
+                cancellationToken);
         }
 
         /// <summary>
-        /// Removes a client ID from a connection's enabled_clients field with mutex protection.
+        /// A status code + errorCode pair that the per-pair membership endpoints may return
+        /// to indicate the desired state already holds. Treated as a no-op.
         /// </summary>
-        /// <param name="api">Auth0 Management API client</param>
-        /// <param name="connectionId">Connection ID to update</param>
-        /// <param name="clientId">Client ID to remove from enabled_clients</param>
-        /// <param name="cancellationToken">Cancellation token</param>
-        async Task RemoveClientFromConnection(IManagementApiClient api, string connectionId, string clientId,
+        private readonly record struct BenignOutcome(HttpStatusCode Status, string ErrorCode, string Label)
+        {
+            public static readonly BenignOutcome AlreadyEnabled =
+                new(HttpStatusCode.Conflict, "connection_client_already_enabled", "already_enabled");
+            public static readonly BenignOutcome NotEnabled =
+                new(HttpStatusCode.NotFound, "connection_client_not_found", "not_enabled");
+        }
+
+        private async Task IssueAtomicMembershipChangeAsync(ITenantApiAccess tenantApiAccess, string connectionId,
+            string clientId, Func<HttpRequestMessage> requestFactory, string operation, BenignOutcome benign,
             CancellationToken cancellationToken)
         {
-            var mutex = _connectionUpdateMutexes.GetOrAdd(connectionId, _ => new SemaphoreSlim(1, 1));
+            var response = await SendWithTokenAndRetryAsync(tenantApiAccess, requestFactory, operation, cancellationToken);
 
-            await mutex.WaitAsync(cancellationToken);
-            try
+            if (response.IsSuccessStatusCode)
             {
-                var currentConnection = await GetConnectionForUpdate(connectionId, clientId, "enabled_clients removal",
-                    cancellationToken, api);
-                if (currentConnection is null) return;
+                response.Dispose();
+                return;
+            }
 
-                var enabledClientIds = GetCurrentEnabledClients(connectionId, currentConnection);
-                if (!IsClientCurrentlyEnabled(connectionId, clientId, enabledClientIds)) return;
+            if (response.StatusCode == benign.Status)
+            {
+                var errorCode = await ReadErrorCodeAsync(response, cancellationToken);
+                if (string.Equals(errorCode, benign.ErrorCode, StringComparison.Ordinal))
+                {
+                    Logger.LogInformationJson(
+                        $"{EntityTypeName} client {clientId} {benign.Label} on connection {connectionId} (Auth0 {(int)benign.Status} errorCode={errorCode}) — no-op",
+                        new { entityTypeName = EntityTypeName, connectionId, clientId, errorCode, operation, status = benign.Label });
+                    response.Dispose();
+                    return;
+                }
+            }
 
-                await UpdateConnectionWithRemovedClient(api, connectionId, clientId, enabledClientIds,
+            await ThrowFromHttpFailureAsync(response, operation, connectionId, clientId, cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends an authenticated HTTP request, evicting and refreshing the bearer token once on a 401 response.
+        /// </summary>
+        private async Task<HttpResponseMessage> SendWithTokenAndRetryAsync(ITenantApiAccess tenantApiAccess,
+            Func<HttpRequestMessage> requestFactory, string operation, CancellationToken cancellationToken)
+        {
+            var httpClient = _httpClientFactory.CreateClient();
+
+            HttpRequestMessage Build(string token)
+            {
+                var req = requestFactory();
+                req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                return req;
+            }
+
+            var response = await httpClient.SendAsync(Build(await tenantApiAccess.GetAccessTokenAsync(cancellationToken)),
+                cancellationToken);
+
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
+            {
+                response.Dispose();
+                await tenantApiAccess.InvalidateAccessTokenAsync(cancellationToken);
+                response = await httpClient.SendAsync(Build(await tenantApiAccess.GetAccessTokenAsync(cancellationToken)),
                     cancellationToken);
             }
-            catch (Exception ex)
+
+            return response;
+        }
+
+        /// <summary>
+        /// Parses Auth0's <c>{ statusCode, error, message, errorCode }</c> error body and returns
+        /// the <c>errorCode</c>, or <c>null</c> when the body is missing/unparseable.
+        /// </summary>
+        private static async Task<string?> ReadErrorCodeAsync(HttpResponseMessage response,
+            CancellationToken cancellationToken)
+        {
+            try
             {
-                LogConnectionUpdateError(connectionId, clientId, "remove_enabled_clients", ex);
-                throw;
+                var body = await response.Content.ReadAsStringAsync(cancellationToken);
+                if (string.IsNullOrWhiteSpace(body))
+                    return null;
+                return Newtonsoft.Json.JsonConvert.DeserializeObject<Auth0ErrorResponse>(body)?.ErrorCode;
             }
-            finally
+            catch
             {
-                mutex.Release();
+                return null;
             }
         }
 
-        private bool IsClientCurrentlyEnabled(string connectionId, string clientId, List<string> enabledClientIds)
+        /// <summary>
+        /// Throws an exception that preserves the status code and Auth0 body for the upstream retry+backoff wrapper.
+        /// 429 maps to <see cref="RateLimitApiException"/> so the existing rate-limit handler reschedules per <c>X-RateLimit-Reset</c>.
+        /// </summary>
+        private async Task ThrowFromHttpFailureAsync(HttpResponseMessage response, string operation,
+            string connectionId, string clientId, CancellationToken cancellationToken)
         {
-            if (!enabledClientIds.Contains(clientId))
+            string body;
+            try { body = await response.Content.ReadAsStringAsync(cancellationToken); }
+            catch { body = string.Empty; }
+
+            var statusCode = (int)response.StatusCode;
+
+            if (statusCode == 429)
             {
-                Logger.LogInformationJson(
-                    $"{EntityTypeName} client {clientId} not currently enabled for connection {connectionId}", new
-                    {
-                        entityTypeName = EntityTypeName,
-                        connectionId,
-                        clientId,
-                        operation = "enabled_clients_check",
-                        status = "not_enabled"
-                    });
-                return false;
+                var rateLimit = RateLimit.Parse(response.Headers);
+                var apiError = await ApiError.Parse(response);
+                response.Dispose();
+                throw new RateLimitApiException(rateLimit, apiError);
             }
 
-            return true;
-        }
-
-        private async Task UpdateConnectionWithRemovedClient(IManagementApiClient api, string connectionId,
-            string clientId, List<string> enabledClientIds, CancellationToken cancellationToken)
-        {
-            enabledClientIds.Remove(clientId);
-
-            var updateRequest = new ConnectionUpdateRequest
-            {
-#pragma warning disable CS0618 // Type or member is obsolete
-                EnabledClients = enabledClientIds.ToArray()
-#pragma warning restore CS0618 // Type or member is obsolete
-            };
-
-            Logger.LogInformationJson(
-                $"{EntityTypeName} updating connection {connectionId} to remove client {clientId} from enabled_clients",
-                new
-                {
-                    entityTypeName = EntityTypeName,
-                    connectionId,
-                    clientId,
-                    operation = "remove_enabled_clients"
-                });
-
-            LogAuth0ApiCall($"Updating Auth0 connection enabled_clients removal: {connectionId}",
-                Auth0ApiCallType.Write, "A0Connection", connectionId, "unknown", "update_connection_remove_clients");
-            await api.Connections.UpdateAsync(connectionId, updateRequest, cancellationToken);
-
-            InvalidateConnectionCache(connectionId);
-
-            Logger.LogInformationJson(
-                $"{EntityTypeName} successfully removed client {clientId} from connection {connectionId} enabled_clients",
-                new
-                {
-                    entityTypeName = EntityTypeName,
-                    connectionId,
-                    clientId,
-                    operation = "remove_enabled_clients",
-                    status = "success"
-                });
-        }
-
-        private void LogConnectionUpdateError(string connectionId, string clientId, string operation, Exception ex)
-        {
-            Logger.LogErrorJson(
-                $"{EntityTypeName} failed to update connection {connectionId} for client {clientId}: {ex.Message}", new
-                {
-                    entityTypeName = EntityTypeName,
-                    connectionId,
-                    clientId,
-                    operation,
-                    errorMessage = ex.Message,
-                    status = "failed"
-                }, ex);
+            response.Dispose();
+            throw new HttpRequestException(
+                $"Auth0 {operation} for client {clientId} on connection {connectionId} returned HTTP {statusCode}: {body}");
         }
 
         /// <summary>
@@ -1766,7 +1562,8 @@ namespace Alethic.Auth0.Operator.Controllers
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The enriched client state with enabled_connections field</returns>
         public async Task<Hashtable> EnrichWithEnabledConnections(Hashtable clientState,
-            ITenantApiAccess tenantApiAccess, string clientId, CancellationToken cancellationToken)
+            ITenantApiAccess tenantApiAccess, string clientId, string defaultNamespace,
+            CancellationToken cancellationToken)
         {
             try
             {
@@ -1780,7 +1577,7 @@ namespace Alethic.Auth0.Operator.Controllers
                     });
 
                 // Get the current enabled connections from Auth0 using direct HTTP call
-                var enabledConnections = await GetClientConnectionsAsync(tenantApiAccess, clientId, cancellationToken);
+                var enabledConnections = await GetClientConnectionsAsync(tenantApiAccess, clientId, defaultNamespace, cancellationToken);
 
                 // Create a list of connection IDs to match the expected format in the client configuration
                 // Need to populate `clientState["enabled_connections"]` with an array of hashtables, each containing key="id" and value= the connection ID
@@ -1856,7 +1653,7 @@ namespace Alethic.Auth0.Operator.Controllers
                 }
 
                 // Enrich with enabled connections using the existing method
-                return await EnrichWithEnabledConnections(auth0State, tenantApiAccess, entity.Status.Id, cancellationToken);
+                return await EnrichWithEnabledConnections(auth0State, tenantApiAccess, entity.Status.Id, entity.Namespace(), cancellationToken);
             }
             catch (Exception ex)
             {
@@ -1995,14 +1792,5 @@ namespace Alethic.Auth0.Operator.Controllers
                 // Don't throw - secret deletion failure shouldn't block tenant change handling
             }
         }
-    }
-
-    /// <summary>
-    /// Wrapper class for Auth0 client connections API response
-    /// </summary>
-    internal class ClientConnectionsResponse
-    {
-        [Newtonsoft.Json.JsonProperty("connections")]
-        public List<Connection> Connections { get; set; } = new List<Connection>();
     }
 }

--- a/src/Alethic.Auth0.Operator/Controllers/V1ClientController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1ClientController.cs
@@ -27,6 +27,7 @@ using KubeOps.KubernetesClient;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
 
 namespace Alethic.Auth0.Operator.Controllers
 {
@@ -1188,16 +1189,18 @@ namespace Alethic.Auth0.Operator.Controllers
             // Use the direct Auth0 Management API endpoint: GET /api/v2/clients/{id}/connections
             var requestUri = new Uri(tenantApiAccess.BaseUri, $"clients/{clientId}/connections");
 
-            var response = await SendWithTokenAndRetryAsync(tenantApiAccess,
+            using var response = await SendWithTokenAndRetryAsync(tenantApiAccess,
                 () => new HttpRequestMessage(HttpMethod.Get, requestUri),
                 operation: "get_client_connections",
                 cancellationToken);
 
             if (!response.IsSuccessStatusCode)
-                await ThrowFromHttpFailureAsync(response, "get_client_connections", connectionId: "-",
-                    clientId, cancellationToken);
+            {
+                var failureBody = await ReadBodySafelyAsync(response, cancellationToken);
+                await ThrowFromHttpFailureAsync(response, failureBody, "get_client_connections",
+                    connectionId: "-", clientId, cancellationToken);
+            }
 
-            using (response)
             {
                 var jsonContent = await response.Content.ReadAsStringAsync(cancellationToken);
                 var responseData =
@@ -1380,28 +1383,31 @@ namespace Alethic.Auth0.Operator.Controllers
             string clientId, Func<HttpRequestMessage> requestFactory, string operation, BenignOutcome benign,
             CancellationToken cancellationToken)
         {
-            var response = await SendWithTokenAndRetryAsync(tenantApiAccess, requestFactory, operation, cancellationToken);
+            using var response = await SendWithTokenAndRetryAsync(tenantApiAccess, requestFactory, operation, cancellationToken);
 
             if (response.IsSuccessStatusCode)
             {
-                response.Dispose();
+                Logger.LogInformationJson(
+                    $"{EntityTypeName} {operation} succeeded for client {clientId} on connection {connectionId}",
+                    new { entityTypeName = EntityTypeName, connectionId, clientId, operation, status = "success" });
                 return;
             }
 
+            var body = await ReadBodySafelyAsync(response, cancellationToken);
+
             if (response.StatusCode == benign.Status)
             {
-                var errorCode = await ReadErrorCodeAsync(response, cancellationToken);
+                var errorCode = ParseErrorCode(body);
                 if (string.Equals(errorCode, benign.ErrorCode, StringComparison.Ordinal))
                 {
                     Logger.LogInformationJson(
                         $"{EntityTypeName} client {clientId} {benign.Label} on connection {connectionId} (Auth0 {(int)benign.Status} errorCode={errorCode}) — no-op",
                         new { entityTypeName = EntityTypeName, connectionId, clientId, errorCode, operation, status = benign.Label });
-                    response.Dispose();
                     return;
                 }
             }
 
-            await ThrowFromHttpFailureAsync(response, operation, connectionId, clientId, cancellationToken);
+            await ThrowFromHttpFailureAsync(response, body, operation, connectionId, clientId, cancellationToken);
         }
 
         /// <summary>
@@ -1435,18 +1441,35 @@ namespace Alethic.Auth0.Operator.Controllers
         }
 
         /// <summary>
-        /// Parses Auth0's <c>{ statusCode, error, message, errorCode }</c> error body and returns
-        /// the <c>errorCode</c>, or <c>null</c> when the body is missing/unparseable.
+        /// Reads the response body, swallowing IO/decode errors so callers can pass the body
+        /// through both the benign-error code-check path and the failure-throw path without
+        /// re-reading the stream (which Auth0 has already exhausted on the wire).
         /// </summary>
-        private static async Task<string?> ReadErrorCodeAsync(HttpResponseMessage response,
+        private static async Task<string> ReadBodySafelyAsync(HttpResponseMessage response,
             CancellationToken cancellationToken)
         {
             try
             {
-                var body = await response.Content.ReadAsStringAsync(cancellationToken);
-                if (string.IsNullOrWhiteSpace(body))
-                    return null;
-                return Newtonsoft.Json.JsonConvert.DeserializeObject<Auth0ErrorResponse>(body)?.ErrorCode;
+                return await response.Content.ReadAsStringAsync(cancellationToken);
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Parses Auth0's <c>{ statusCode, error, message, errorCode }</c> error body and returns
+        /// the <c>errorCode</c>, or <c>null</c> when the body is missing/unparseable. Pure helper:
+        /// no IO, no allocations beyond the JSON deserialization.
+        /// </summary>
+        private static string? ParseErrorCode(string body)
+        {
+            if (string.IsNullOrWhiteSpace(body))
+                return null;
+            try
+            {
+                return JsonConvert.DeserializeObject<Auth0ErrorResponse>(body)?.ErrorCode;
             }
             catch
             {
@@ -1457,25 +1480,30 @@ namespace Alethic.Auth0.Operator.Controllers
         /// <summary>
         /// Throws an exception that preserves the status code and Auth0 body for the upstream retry+backoff wrapper.
         /// 429 maps to <see cref="RateLimitApiException"/> so the existing rate-limit handler reschedules per <c>X-RateLimit-Reset</c>.
+        /// Callers own the response lifetime (via <c>using</c>); this method does not dispose it.
         /// </summary>
-        private async Task ThrowFromHttpFailureAsync(HttpResponseMessage response, string operation,
+        private Task ThrowFromHttpFailureAsync(HttpResponseMessage response, string body, string operation,
             string connectionId, string clientId, CancellationToken cancellationToken)
         {
-            string body;
-            try { body = await response.Content.ReadAsStringAsync(cancellationToken); }
-            catch { body = string.Empty; }
-
             var statusCode = (int)response.StatusCode;
 
             if (statusCode == 429)
             {
                 var rateLimit = RateLimit.Parse(response.Headers);
-                var apiError = await ApiError.Parse(response);
-                response.Dispose();
+                ApiError apiError;
+                try
+                {
+                    apiError = (string.IsNullOrWhiteSpace(body)
+                        ? null
+                        : JsonConvert.DeserializeObject<ApiError>(body)) ?? new ApiError();
+                }
+                catch
+                {
+                    apiError = new ApiError();
+                }
                 throw new RateLimitApiException(rateLimit, apiError);
             }
 
-            response.Dispose();
             throw new HttpRequestException(
                 $"Auth0 {operation} for client {clientId} on connection {connectionId} returned HTTP {statusCode}: {body}");
         }

--- a/src/Alethic.Auth0.Operator/Controllers/V1ClientController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1ClientController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -1197,29 +1198,27 @@ namespace Alethic.Auth0.Operator.Controllers
             if (!response.IsSuccessStatusCode)
             {
                 var failureBody = await ReadBodySafelyAsync(response, cancellationToken);
-                await ThrowFromHttpFailureAsync(response, failureBody, "get_client_connections",
-                    connectionId: "-", clientId, cancellationToken);
+                ThrowFromHttpFailure(response, failureBody, "get_client_connections",
+                    connectionId: "-", clientId);
             }
 
-            {
-                var jsonContent = await response.Content.ReadAsStringAsync(cancellationToken);
-                var responseData =
-                    Newtonsoft.Json.JsonConvert.DeserializeObject<ClientConnectionsResponse>(jsonContent);
-                var connections = responseData?.Connections;
+            var jsonContent = await response.Content.ReadAsStringAsync(cancellationToken);
+            var responseData =
+                Newtonsoft.Json.JsonConvert.DeserializeObject<ClientConnectionsResponse>(jsonContent);
+            var connections = responseData?.Connections;
 
-                Logger.LogInformationJson(
-                    $"{EntityTypeName} retrieved {connections?.Count ?? 0} connections directly for client {clientId}",
-                    new
-                    {
-                        entityTypeName = EntityTypeName,
-                        clientId,
-                        connectionCount = connections?.Count ?? 0,
-                        operation = "get_client_connections_direct",
-                        baseUri = tenantApiAccess.BaseUri.ToString()
-                    });
+            Logger.LogInformationJson(
+                $"{EntityTypeName} retrieved {connections?.Count ?? 0} connections directly for client {clientId}",
+                new
+                {
+                    entityTypeName = EntityTypeName,
+                    clientId,
+                    connectionCount = connections?.Count ?? 0,
+                    operation = "get_client_connections_direct",
+                    baseUri = tenantApiAccess.BaseUri.ToString()
+                });
 
-                return connections ?? new List<Connection>();
-            }
+            return connections ?? new List<Connection>();
         }
 
 
@@ -1235,7 +1234,8 @@ namespace Alethic.Auth0.Operator.Controllers
                 var (connectionsToAdd, connectionsToRemove) =
                     CalculateConnectionDifferences(currentConnectionIds, desiredConnectionIds);
 
-                await ApplyConnectionChanges(tenantApiAccess, clientId, connectionsToAdd, connectionsToRemove, cancellationToken);
+                await ApplyConnectionChanges(tenantApiAccess, clientId, connectionsToAdd, connectionsToRemove,
+                    defaultNamespace, cancellationToken);
                 LogReconciliationResult(clientId, currentConnectionIds.Count, connectionsToAdd.Count,
                     connectionsToRemove.Count);
             }
@@ -1298,13 +1298,15 @@ namespace Alethic.Auth0.Operator.Controllers
 
         private async Task ApplyConnectionChanges(ITenantApiAccess tenantApiAccess, string clientId,
             List<string> connectionsToAdd, List<string> connectionsToRemove,
-            CancellationToken cancellationToken)
+            string defaultNamespace, CancellationToken cancellationToken)
         {
             foreach (var connectionId in connectionsToAdd)
-                await EnableClientOnConnectionAsync(tenantApiAccess, connectionId, clientId, cancellationToken);
+                await EnableClientOnConnectionAsync(tenantApiAccess, connectionId, clientId, defaultNamespace,
+                    cancellationToken);
 
             foreach (var connectionId in connectionsToRemove)
-                await DisableClientOnConnectionAsync(tenantApiAccess, connectionId, clientId, cancellationToken);
+                await DisableClientOnConnectionAsync(tenantApiAccess, connectionId, clientId, defaultNamespace,
+                    cancellationToken);
         }
 
         private void LogReconciliationResult(string clientId, int currentConnectionCount, int addedCount,
@@ -1339,21 +1341,23 @@ namespace Alethic.Auth0.Operator.Controllers
 
         /// <summary>PATCH /api/v2/connections/{connectionId}/clients with <c>[{client_id, status:true}]</c> — enables a single client on a connection.</summary>
         internal Task EnableClientOnConnectionAsync(ITenantApiAccess tenantApiAccess, string connectionId,
-            string clientId, CancellationToken cancellationToken)
+            string clientId, string defaultNamespace, CancellationToken cancellationToken)
         {
             return PatchConnectionClientsAsync(tenantApiAccess, connectionId, clientId,
                 status: true,
                 operation: "enable_client_on_connection",
+                defaultNamespace,
                 cancellationToken);
         }
 
         /// <summary>PATCH /api/v2/connections/{connectionId}/clients with <c>[{client_id, status:false}]</c> — disables a single client on a connection.</summary>
         internal Task DisableClientOnConnectionAsync(ITenantApiAccess tenantApiAccess, string connectionId,
-            string clientId, CancellationToken cancellationToken)
+            string clientId, string defaultNamespace, CancellationToken cancellationToken)
         {
             return PatchConnectionClientsAsync(tenantApiAccess, connectionId, clientId,
                 status: false,
                 operation: "disable_client_on_connection",
+                defaultNamespace,
                 cancellationToken);
         }
 
@@ -1361,11 +1365,11 @@ namespace Alethic.Auth0.Operator.Controllers
         /// Issues a single <c>PATCH /api/v2/connections/{connectionId}/clients</c> with a one-row
         /// body <c>[{client_id, status}]</c> — Auth0's replacement for the deprecated
         /// <c>enabled_clients</c> field. Success is HTTP 204 (No Content); any other status surfaces
-        /// via <see cref="ThrowFromHttpFailureAsync"/>. No benign-4xx handling is required because
+        /// via <see cref="ThrowFromHttpFailure"/>. No benign-4xx handling is required because
         /// the endpoint is idempotent and returns 204 regardless of prior membership state.
         /// </summary>
         private async Task PatchConnectionClientsAsync(ITenantApiAccess tenantApiAccess, string connectionId,
-            string clientId, bool status, string operation,
+            string clientId, bool status, string operation, string defaultNamespace,
             CancellationToken cancellationToken)
         {
             var requestUri = new Uri(tenantApiAccess.BaseUri, $"connections/{connectionId}/clients");
@@ -1375,7 +1379,7 @@ namespace Alethic.Auth0.Operator.Controllers
             });
 
             LogAuth0ApiCall($"{operation} for client {clientId} on connection {connectionId}",
-                Auth0ApiCallType.Write, "A0Client", clientId, "unknown", operation);
+                Auth0ApiCallType.Write, "A0Client", clientId, defaultNamespace, operation);
 
             using var response = await SendWithTokenAndRetryAsync(tenantApiAccess,
                 () => new HttpRequestMessage(HttpMethod.Patch, requestUri)
@@ -1393,7 +1397,7 @@ namespace Alethic.Auth0.Operator.Controllers
             }
 
             var body = await ReadBodySafelyAsync(response, cancellationToken);
-            await ThrowFromHttpFailureAsync(response, body, operation, connectionId, clientId, cancellationToken);
+            ThrowFromHttpFailure(response, body, operation, connectionId, clientId);
         }
 
         /// <summary>
@@ -1449,8 +1453,9 @@ namespace Alethic.Auth0.Operator.Controllers
         /// 429 maps to <see cref="RateLimitApiException"/> so the existing rate-limit handler reschedules per <c>X-RateLimit-Reset</c>.
         /// Callers own the response lifetime (via <c>using</c>); this method does not dispose it.
         /// </summary>
-        private Task ThrowFromHttpFailureAsync(HttpResponseMessage response, string body, string operation,
-            string connectionId, string clientId, CancellationToken cancellationToken)
+        [DoesNotReturn]
+        private static void ThrowFromHttpFailure(HttpResponseMessage response, string body, string operation,
+            string connectionId, string clientId)
         {
             var statusCode = (int)response.StatusCode;
 

--- a/src/Alethic.Auth0.Operator/Controllers/V1ClientController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1ClientController.cs
@@ -1337,53 +1337,52 @@ namespace Alethic.Auth0.Operator.Controllers
                 }, ex);
         }
 
-        /// <summary>POST /api/v2/connections/{connectionId}/clients — enables a single client on a connection.</summary>
+        /// <summary>PATCH /api/v2/connections/{connectionId}/clients with <c>[{client_id, status:true}]</c> — enables a single client on a connection.</summary>
         internal Task EnableClientOnConnectionAsync(ITenantApiAccess tenantApiAccess, string connectionId,
             string clientId, CancellationToken cancellationToken)
         {
-            var requestUri = new Uri(tenantApiAccess.BaseUri, $"connections/{connectionId}/clients");
-            var payload = Newtonsoft.Json.JsonConvert.SerializeObject(new { client_id = clientId });
-
-            return IssueAtomicMembershipChangeAsync(tenantApiAccess, connectionId, clientId,
-                () => new HttpRequestMessage(HttpMethod.Post, requestUri)
-                {
-                    Content = new StringContent(payload, Encoding.UTF8, "application/json")
-                },
+            return PatchConnectionClientsAsync(tenantApiAccess, connectionId, clientId,
+                status: true,
                 operation: "enable_client_on_connection",
-                benign: BenignOutcome.AlreadyEnabled,
                 cancellationToken);
         }
 
-        /// <summary>DELETE /api/v2/connections/{connectionId}/clients/{clientId} — disables a single client on a connection.</summary>
+        /// <summary>PATCH /api/v2/connections/{connectionId}/clients with <c>[{client_id, status:false}]</c> — disables a single client on a connection.</summary>
         internal Task DisableClientOnConnectionAsync(ITenantApiAccess tenantApiAccess, string connectionId,
             string clientId, CancellationToken cancellationToken)
         {
-            var requestUri = new Uri(tenantApiAccess.BaseUri, $"connections/{connectionId}/clients/{clientId}");
-
-            return IssueAtomicMembershipChangeAsync(tenantApiAccess, connectionId, clientId,
-                () => new HttpRequestMessage(HttpMethod.Delete, requestUri),
+            return PatchConnectionClientsAsync(tenantApiAccess, connectionId, clientId,
+                status: false,
                 operation: "disable_client_on_connection",
-                benign: BenignOutcome.NotEnabled,
                 cancellationToken);
         }
 
         /// <summary>
-        /// A status code + errorCode pair that the per-pair membership endpoints may return
-        /// to indicate the desired state already holds. Treated as a no-op.
+        /// Issues a single <c>PATCH /api/v2/connections/{connectionId}/clients</c> with a one-row
+        /// body <c>[{client_id, status}]</c> — Auth0's replacement for the deprecated
+        /// <c>enabled_clients</c> field. Success is HTTP 204 (No Content); any other status surfaces
+        /// via <see cref="ThrowFromHttpFailureAsync"/>. No benign-4xx handling is required because
+        /// the endpoint is idempotent and returns 204 regardless of prior membership state.
         /// </summary>
-        private readonly record struct BenignOutcome(HttpStatusCode Status, string ErrorCode, string Label)
-        {
-            public static readonly BenignOutcome AlreadyEnabled =
-                new(HttpStatusCode.Conflict, "connection_client_already_enabled", "already_enabled");
-            public static readonly BenignOutcome NotEnabled =
-                new(HttpStatusCode.NotFound, "connection_client_not_found", "not_enabled");
-        }
-
-        private async Task IssueAtomicMembershipChangeAsync(ITenantApiAccess tenantApiAccess, string connectionId,
-            string clientId, Func<HttpRequestMessage> requestFactory, string operation, BenignOutcome benign,
+        private async Task PatchConnectionClientsAsync(ITenantApiAccess tenantApiAccess, string connectionId,
+            string clientId, bool status, string operation,
             CancellationToken cancellationToken)
         {
-            using var response = await SendWithTokenAndRetryAsync(tenantApiAccess, requestFactory, operation, cancellationToken);
+            var requestUri = new Uri(tenantApiAccess.BaseUri, $"connections/{connectionId}/clients");
+            var payload = Newtonsoft.Json.JsonConvert.SerializeObject(new[]
+            {
+                new { client_id = clientId, status }
+            });
+
+            LogAuth0ApiCall($"{operation} for client {clientId} on connection {connectionId}",
+                Auth0ApiCallType.Write, "A0Client", clientId, "unknown", operation);
+
+            using var response = await SendWithTokenAndRetryAsync(tenantApiAccess,
+                () => new HttpRequestMessage(HttpMethod.Patch, requestUri)
+                {
+                    Content = new StringContent(payload, Encoding.UTF8, "application/json")
+                },
+                operation, cancellationToken);
 
             if (response.IsSuccessStatusCode)
             {
@@ -1394,19 +1393,6 @@ namespace Alethic.Auth0.Operator.Controllers
             }
 
             var body = await ReadBodySafelyAsync(response, cancellationToken);
-
-            if (response.StatusCode == benign.Status)
-            {
-                var errorCode = ParseErrorCode(body);
-                if (string.Equals(errorCode, benign.ErrorCode, StringComparison.Ordinal))
-                {
-                    Logger.LogInformationJson(
-                        $"{EntityTypeName} client {clientId} {benign.Label} on connection {connectionId} (Auth0 {(int)benign.Status} errorCode={errorCode}) — no-op",
-                        new { entityTypeName = EntityTypeName, connectionId, clientId, errorCode, operation, status = benign.Label });
-                    return;
-                }
-            }
-
             await ThrowFromHttpFailureAsync(response, body, operation, connectionId, clientId, cancellationToken);
         }
 
@@ -1455,25 +1441,6 @@ namespace Alethic.Auth0.Operator.Controllers
             catch
             {
                 return string.Empty;
-            }
-        }
-
-        /// <summary>
-        /// Parses Auth0's <c>{ statusCode, error, message, errorCode }</c> error body and returns
-        /// the <c>errorCode</c>, or <c>null</c> when the body is missing/unparseable. Pure helper:
-        /// no IO, no allocations beyond the JSON deserialization.
-        /// </summary>
-        private static string? ParseErrorCode(string body)
-        {
-            if (string.IsNullOrWhiteSpace(body))
-                return null;
-            try
-            {
-                return JsonConvert.DeserializeObject<Auth0ErrorResponse>(body)?.ErrorCode;
-            }
-            catch
-            {
-                return null;
             }
         }
 

--- a/src/Alethic.Auth0.Operator/Controllers/V1ClientControllerWireModels.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1ClientControllerWireModels.cs
@@ -8,19 +8,4 @@ namespace Alethic.Auth0.Operator.Controllers
         [Newtonsoft.Json.JsonProperty("connections")]
         public List<Connection> Connections { get; set; } = new List<Connection>();
     }
-
-    internal class Auth0ErrorResponse
-    {
-        [Newtonsoft.Json.JsonProperty("statusCode")]
-        public int StatusCode { get; set; }
-
-        [Newtonsoft.Json.JsonProperty("error")]
-        public string? Error { get; set; }
-
-        [Newtonsoft.Json.JsonProperty("message")]
-        public string? Message { get; set; }
-
-        [Newtonsoft.Json.JsonProperty("errorCode")]
-        public string? ErrorCode { get; set; }
-    }
 }

--- a/src/Alethic.Auth0.Operator/Controllers/V1ClientControllerWireModels.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1ClientControllerWireModels.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using Auth0.ManagementApi.Models;
+
+namespace Alethic.Auth0.Operator.Controllers
+{
+    internal class ClientConnectionsResponse
+    {
+        [Newtonsoft.Json.JsonProperty("connections")]
+        public List<Connection> Connections { get; set; } = new List<Connection>();
+    }
+
+    internal class Auth0ErrorResponse
+    {
+        [Newtonsoft.Json.JsonProperty("statusCode")]
+        public int StatusCode { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("error")]
+        public string? Error { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("message")]
+        public string? Message { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("errorCode")]
+        public string? ErrorCode { get; set; }
+    }
+}

--- a/src/Alethic.Auth0.Operator/Controllers/V1Controller.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1Controller.cs
@@ -55,6 +55,14 @@ namespace Alethic.Auth0.Operator.Controllers
         private const int MaxRetryDelaySeconds = 300;
         protected const int MaxTenantChangeRetryAttempts = 2;
 
+        /// <summary>
+        /// Base delay (seconds) used by <see cref="GenerateExceptionRetryDelay"/> for the
+        /// always-requeue-on-exception path in <see cref="ReconcileAsync"/>. The delay is
+        /// "<see cref="ExceptionRetryBaseSeconds"/> ±25% jitter" — i.e. 22.5s–37.5s with the
+        /// current 30s base.
+        /// </summary>
+        private const int ExceptionRetryBaseSeconds = 30;
+
         static readonly Newtonsoft.Json.JsonSerializer _newtonsoftJsonSerializer = Newtonsoft.Json.JsonSerializer.CreateDefault();
         static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web) { Converters = { new SimplePrimitiveHashtableConverter() } };
         static readonly SemaphoreSlim _getTenantApiClient = new(1);
@@ -590,30 +598,51 @@ namespace Alethic.Auth0.Operator.Controllers
                 });
                 await ReconcileSuccessAsync(entity, cancellationToken);
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Reconcile was cancelled (e.g. operator shutdown, controller restart, or an
+                // outer caller cancelled the token). Do NOT swallow into Requeue — the host
+                // owns the cancellation contract.
+                throw;
+            }
             catch (ErrorApiException e)
             {
                 try
                 {
                     var duration = DateTimeOffset.UtcNow - startTime;
-                    Logger.LogErrorJson($"Auth0 API error during reconciliation for {EntityTypeName} {entity.Namespace()}/{entity.Name()}: Status={e.StatusCode}, ErrorCode={e.ApiError?.ErrorCode}, Message={e.ApiError?.Message}, Duration={duration.TotalMilliseconds}ms", new { 
+                    Logger.LogErrorJson($"Auth0 API error during reconciliation for {EntityTypeName} {entity.Namespace()}/{entity.Name()}: Status={e.StatusCode}, ErrorCode={e.ApiError?.ErrorCode}, Message={e.ApiError?.Message}, Duration={duration.TotalMilliseconds}ms", new {
                         entityTypeName = EntityTypeName,
-                        entityNamespace = entity.Namespace(), 
-                        entityName = entity.Name(), 
+                        entityNamespace = entity.Namespace(),
+                        entityName = entity.Name(),
                         statusCode = e.StatusCode.ToString(),
                         errorCode = e.ApiError?.ErrorCode,
                         apiErrorMessage = e.ApiError?.Message,
-                        durationMs = duration.TotalMilliseconds 
+                        durationMs = duration.TotalMilliseconds
                     }, e);
                     await ReconcileWarningAsync(entity, "ApiError", e.ApiError?.Message ?? e.Message, cancellationToken);
                 }
                 catch (Exception e2)
                 {
-                    Logger.LogCriticalJson($"Unexpected exception creating event for {EntityTypeName} {entity.Namespace()}/{entity.Name()}", new { 
+                    Logger.LogCriticalJson($"Unexpected exception creating event for {EntityTypeName} {entity.Namespace()}/{entity.Name()}", new {
                         entityTypeName = EntityTypeName,
-                        entityNamespace = entity.Namespace(), 
-                        entityName = entity.Name() 
+                        entityNamespace = entity.Namespace(),
+                        entityName = entity.Name()
                     }, e2);
                 }
+
+                // Always-requeue: the prior implementation logged-and-fell-through here,
+                // which left the reconcile loop silent for the resource until a watch
+                // event or operator restart fired. Schedule an explicit retry.
+                var apiRetryDelay = GenerateExceptionRetryDelay();
+                Logger.LogWarningJson($"Auth0 API error — rescheduling reconciliation after {apiRetryDelay}", new
+                {
+                    entityTypeName = EntityTypeName,
+                    entityNamespace = entity.Namespace(),
+                    entityName = entity.Name(),
+                    rescheduleAfter = apiRetryDelay.ToString(),
+                    operation = "requeue_after_api_error"
+                });
+                Requeue(entity, apiRetryDelay);
             }
             catch (RateLimitApiException e)
             {
@@ -678,33 +707,60 @@ namespace Alethic.Auth0.Operator.Controllers
                 });
                 Requeue(entity, TimeSpan.FromMinutes(1));
             }
-            catch (Exception e)
+            catch (Exception e) when (!IsProgrammerBug(e) && !cancellationToken.IsCancellationRequested)
             {
                 try
                 {
                     var duration = DateTimeOffset.UtcNow - startTime;
-                    Logger.LogErrorJson($"Unexpected error reconciling {EntityTypeName} {entity.Namespace()}/{entity.Name()}: {e.GetType().Name} - {e.Message}, Duration={duration.TotalMilliseconds}ms", new { 
+                    Logger.LogErrorJson($"Unexpected error reconciling {EntityTypeName} {entity.Namespace()}/{entity.Name()}: {e.GetType().Name} - {e.Message}, Duration={duration.TotalMilliseconds}ms", new {
                         entityTypeName = EntityTypeName,
-                        entityNamespace = entity.Namespace(), 
-                        entityName = entity.Name(), 
+                        entityNamespace = entity.Namespace(),
+                        entityName = entity.Name(),
                         exceptionType = e.GetType().Name,
                         errorMessage = e.Message,
-                        durationMs = duration.TotalMilliseconds 
+                        durationMs = duration.TotalMilliseconds
                     }, e);
                     await ReconcileWarningAsync(entity, "Unknown", e.Message, cancellationToken);
                 }
                 catch (Exception e2)
                 {
-                    Logger.LogCriticalJson($"Unexpected exception creating event for {EntityTypeName} {entity.Namespace()}/{entity.Name()}", new { 
+                    Logger.LogCriticalJson($"Unexpected exception creating event for {EntityTypeName} {entity.Namespace()}/{entity.Name()}", new {
                         entityTypeName = EntityTypeName,
-                        entityNamespace = entity.Namespace(), 
-                        entityName = entity.Name() 
+                        entityNamespace = entity.Namespace(),
+                        entityName = entity.Name()
                     }, e2);
                 }
 
-                throw;
+                // Always-requeue: prior implementation re-threw which produced a noisy
+                // crash-loop-style failure with no scheduled retry for this resource.
+                // Call Requeue with a jittered backoff so the operator self-heals after
+                // transient K8s / dependency errors. Programmer-bug exception types are
+                // filtered out above and continue to propagate so they crash-loop and
+                // page on-call as expected.
+                var retryDelay = GenerateExceptionRetryDelay();
+                Logger.LogWarningJson($"Unexpected error — rescheduling reconciliation after {retryDelay}", new
+                {
+                    entityTypeName = EntityTypeName,
+                    entityNamespace = entity.Namespace(),
+                    entityName = entity.Name(),
+                    rescheduleAfter = retryDelay.ToString(),
+                    operation = "requeue_after_unexpected_exception"
+                });
+                Requeue(entity, retryDelay);
             }
         }
+
+        /// <summary>
+        /// Returns true for exception types that almost certainly indicate a programmer bug
+        /// (null deref, bad argument, bad cast, missing type) rather than a transient
+        /// runtime / network / API condition. These propagate uncaught so the host's
+        /// crash-loop / paging machinery handles them — silent-requeue would mask them.
+        /// </summary>
+        private static bool IsProgrammerBug(Exception e) =>
+            e is NullReferenceException
+                or ArgumentException // covers ArgumentNullException, ArgumentOutOfRangeException
+                or InvalidCastException
+                or TypeLoadException;
 
         /// <inheritdoc />
         public abstract Task DeletedAsync(TEntity entity, CancellationToken cancellationToken);
@@ -745,6 +801,19 @@ namespace Alethic.Auth0.Operator.Controllers
         {
             var random = new Random();
             return random.Next(MinRetryDelaySeconds, MaxRetryDelaySeconds + 1);
+        }
+
+        /// <summary>
+        /// Generates the requeue delay used by the always-requeue-on-exception path in
+        /// <see cref="ReconcileAsync"/>. Plain "<see cref="ExceptionRetryBaseSeconds"/>s
+        /// ±25% jitter" — i.e. 22.5–37.5s with the current 30s base. No upper cap is
+        /// applied: the jitter window is bounded by construction.
+        /// </summary>
+        protected TimeSpan GenerateExceptionRetryDelay()
+        {
+            // ±25% jitter: NextDouble() ∈ [0,1) → factor ∈ [0.75, 1.25)
+            var jitterFactor = 0.75 + (Random.Shared.NextDouble() * 0.5);
+            return TimeSpan.FromSeconds(ExceptionRetryBaseSeconds * jitterFactor);
         }
     }
 

--- a/src/Alethic.Auth0.Operator/Controllers/V1TenantEntityController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1TenantEntityController.cs
@@ -377,8 +377,8 @@ namespace Alethic.Auth0.Operator.Controllers
 
         /// <summary>
         /// Delays (in milliseconds) used between attempts of the K8s 409-Conflict retry helper.
-        /// Three attempts total — caller's first attempt + up to two retries — with jittered
-        /// 100 / 400 / 1600 ms pauses between attempts. Plain "100/400/1600 ms ±25% jitter".
+        /// Four attempts total — caller's first attempt + up to three retries (KubeConflictRetryDelaysMs
+        /// has 3 entries: 100 / 400 / 1600 ms with ±25% jitter between attempts).
         /// </summary>
         private static readonly int[] KubeConflictRetryDelaysMs = new[] { 100, 400, 1600 };
 

--- a/src/Alethic.Auth0.Operator/Controllers/V1TenantEntityController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1TenantEntityController.cs
@@ -464,6 +464,11 @@ namespace Alethic.Auth0.Operator.Controllers
         /// </summary>
         internal static TEntity OverlayOperatorOwnedMetadata(TEntity local, TEntity refetched)
         {
+            // H5: Every metadata key written by this operator lives under the
+            // `kubernetes.auth0.com/` prefix (current-client-id, current-tenant-ref,
+            // previous-client-id, previous-tenant-ref, tenant-uid, tenant-name,
+            // tenant-change-retry-count, partition, operator). Restricting the overlay
+            // to this prefix is sufficient — no other operator-owned key escapes.
             const string operatorPrefix = "kubernetes.auth0.com/";
 
             var rmd = refetched.EnsureMetadata();

--- a/src/Alethic.Auth0.Operator/Controllers/V1TenantEntityController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1TenantEntityController.cs
@@ -467,8 +467,11 @@ namespace Alethic.Auth0.Operator.Controllers
             // H5: Every metadata key written by this operator lives under the
             // `kubernetes.auth0.com/` prefix (current-client-id, current-tenant-ref,
             // previous-client-id, previous-tenant-ref, tenant-uid, tenant-name,
-            // tenant-change-retry-count, partition, operator). Restricting the overlay
+            // tenant-change-retry-count, partition). Restricting the overlay
             // to this prefix is sufficient — no other operator-owned key escapes.
+            // For reference (not an annotation key): the EventSource `reportingController`
+            // value is `kubernetes.auth0.com/operator`, which shares the prefix but is
+            // surfaced via Kubernetes events, not metadata.
             const string operatorPrefix = "kubernetes.auth0.com/";
 
             var rmd = refetched.EnsureMetadata();
@@ -497,7 +500,9 @@ namespace Alethic.Auth0.Operator.Controllers
                 }
             }
 
-            // Overlay labels (symmetric)
+            // Overlay labels (symmetric).
+            // Defensive — no operator code currently writes labels; this branch is here so
+            // future label writes are auto-protected by the same allowlist without re-deriving it.
             var localLabels = local.Metadata?.Labels;
             if (localLabels is not null)
             {

--- a/src/Alethic.Auth0.Operator/Controllers/V1TenantEntityController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1TenantEntityController.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,6 +15,7 @@ using Auth0.Core.Exceptions;
 using Auth0.ManagementApi;
 
 using k8s;
+using k8s.Autorest;
 using k8s.Models;
 
 using KubeOps.Abstractions.Queue;
@@ -373,32 +375,68 @@ namespace Alethic.Auth0.Operator.Controllers
             return await UpdateKubernetesStatus(entity, "finding entity", cancellationToken);
         }
 
+        /// <summary>
+        /// Delays (in milliseconds) used between attempts of the K8s 409-Conflict retry helper.
+        /// Three attempts total — caller's first attempt + up to two retries — with jittered
+        /// 100 / 400 / 1600 ms pauses between attempts. Plain "100/400/1600 ms ±25% jitter".
+        /// </summary>
+        private static readonly int[] KubeConflictRetryDelaysMs = new[] { 100, 400, 1600 };
+
+        /// <summary>
+        /// Computes the jittered delay (in ms) for retry attempt <paramref name="attempt"/>
+        /// (1-based: attempt=1 → ~100ms, attempt=2 → ~400ms, …). Clamps to the last entry
+        /// of <see cref="KubeConflictRetryDelaysMs"/> when the attempt index exceeds the table.
+        /// </summary>
+        internal static int ComputeKubeConflictRetryDelayMs(int attempt)
+        {
+            if (attempt < 1)
+                attempt = 1;
+            var idx = Math.Min(attempt - 1, KubeConflictRetryDelaysMs.Length - 1);
+            var baseMs = KubeConflictRetryDelaysMs[idx];
+            // ±25% jitter
+            var jitter = (Random.Shared.NextDouble() - 0.5) * 0.5; // [-0.25, 0.25)
+            return (int)Math.Round(baseMs * (1.0 + jitter));
+        }
+
         protected async Task<TEntity> UpdateKubernetesStatus(TEntity entity, string operation, CancellationToken cancellationToken)
         {
-            try
-            {
-                return await Kube.UpdateStatusAsync(entity, cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                Logger.LogErrorJson($"{EntityTypeName} {entity.Namespace()}/{entity.Name()} failed to update Kubernetes status after {operation}: {ex.Message}", new
+            // Status subresource is safe to retry by "carry resourceVersion forward" — the
+            // /status PUT only reads metadata.resourceVersion + status.* from the body, so
+            // copying the local entity's desired Status onto the refetched object is the
+            // canonical merge. See decisions.md 2026-05-18 entry.
+            return await UpdateKubernetesWithConflictRetryAsync(
+                entity,
+                operation,
+                writeKind: "status",
+                writeAsync: static (kube, e, ct) => kube.UpdateStatusAsync(e, ct),
+                overlayLocalOntoRefetched: static (local, refetched) =>
                 {
-                    entityTypeName = EntityTypeName,
-                    entityNamespace = entity.Namespace(),
-                    entityName = entity.Name(),
-                    operation,
-                    errorMessage = ex.Message
-                }, ex);
-                throw;
-            }
+                    // The interface exposes Status as get-only, so we cannot copy it onto
+                    // the refetched object. Instead, advance only the resourceVersion on
+                    // the in-memory (local) entity and re-issue the status PUT with the
+                    // caller's desired Status object. The /status subresource discards any
+                    // metadata fields outside resourceVersion, so this is safe.
+                    var localMd = local.EnsureMetadata();
+                    localMd.ResourceVersion = refetched.Metadata?.ResourceVersion;
+                    return local;
+                },
+                cancellationToken);
         }
 
         /// <summary>
         /// Updates the entire Kubernetes resource including metadata (annotations, labels) and status.
         /// Use this method when you need to persist annotation changes.
-        /// 
+        ///
         /// Note: PatchAsync would be more efficient but is currently in preview in KubeOps SDK.
         /// UpdateAsync is the stable, production-ready approach for metadata updates.
+        ///
+        /// On HTTP 409 Conflict: refetch the entity from the API server, then re-apply ONLY
+        /// the operator-owned mutations (annotations / labels under the
+        /// <c>kubernetes.auth0.com/</c> prefix) from the in-memory entity onto the refetched
+        /// object before retrying. Annotations / labels owned by other writers (KubeOps
+        /// finalizer machinery, user kubectl patches, other controllers) are preserved as-is
+        /// from the server. This is the "allowlist overlay" mitigation for the metadata-PUT
+        /// clobber risk — see decisions.md 2026-05-18 entry, finding H2.
         /// </summary>
         /// <param name="entity">The entity to update</param>
         /// <param name="operation">Description of the operation for logging</param>
@@ -406,23 +444,159 @@ namespace Alethic.Auth0.Operator.Controllers
         /// <returns>The updated entity</returns>
         protected async Task<TEntity> UpdateKubernetesMetadata(TEntity entity, string operation, CancellationToken cancellationToken)
         {
-            try
+            return await UpdateKubernetesWithConflictRetryAsync(
+                entity,
+                operation,
+                writeKind: "metadata",
+                writeAsync: static (kube, e, ct) => kube.UpdateAsync(e, ct),
+                overlayLocalOntoRefetched: OverlayOperatorOwnedMetadata,
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Allowlist overlay used by the metadata-write retry path. On a 409 refetch we keep
+        /// the server's current metadata as the baseline (preserving finalizers,
+        /// managedFields, third-party annotations/labels), then copy ONLY the
+        /// <c>kubernetes.auth0.com/</c>-prefixed annotation and label keys from the local
+        /// entity onto the refetched object. That guarantees we never silently clobber a
+        /// concurrent writer's keys while still preserving the operator's intended mutation
+        /// from this reconcile pass.
+        /// </summary>
+        internal static TEntity OverlayOperatorOwnedMetadata(TEntity local, TEntity refetched)
+        {
+            const string operatorPrefix = "kubernetes.auth0.com/";
+
+            var rmd = refetched.EnsureMetadata();
+
+            // Overlay annotations
+            var localAnnotations = local.Metadata?.Annotations;
+            if (localAnnotations is not null)
             {
-                // Use UpdateAsync for metadata changes - stable and production-ready
-                // PatchAsync would be more efficient but is currently in preview
-                return await Kube.UpdateAsync(entity, cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                Logger.LogErrorJson($"{EntityTypeName} {entity.Namespace()}/{entity.Name()} failed to update Kubernetes metadata after {operation}: {ex.Message}", new
+                var rAn = rmd.EnsureAnnotations();
+                // Step 1: drop any operator-owned keys that the local entity *removed* (i.e.
+                // exist on the refetched object but not on the local one). This handles
+                // intentional deletions such as ClearTenantChangeRetryCounter.
+                var keysOnRefetched = rAn.Keys
+                    .Where(k => k.StartsWith(operatorPrefix, StringComparison.Ordinal))
+                    .ToList();
+                foreach (var key in keysOnRefetched)
                 {
-                    entityTypeName = EntityTypeName,
-                    entityNamespace = entity.Namespace(),
-                    entityName = entity.Name(),
-                    operation,
-                    errorMessage = ex.Message
-                }, ex);
-                throw;
+                    if (!localAnnotations.ContainsKey(key))
+                        rAn.Remove(key);
+                }
+                // Step 2: copy operator-owned keys from local to refetched.
+                foreach (var kv in localAnnotations)
+                {
+                    if (kv.Key.StartsWith(operatorPrefix, StringComparison.Ordinal))
+                        rAn[kv.Key] = kv.Value;
+                }
+            }
+
+            // Overlay labels (symmetric)
+            var localLabels = local.Metadata?.Labels;
+            if (localLabels is not null)
+            {
+                var rLb = rmd.EnsureLabels();
+                var keysOnRefetched = rLb.Keys
+                    .Where(k => k.StartsWith(operatorPrefix, StringComparison.Ordinal))
+                    .ToList();
+                foreach (var key in keysOnRefetched)
+                {
+                    if (!localLabels.ContainsKey(key))
+                        rLb.Remove(key);
+                }
+                foreach (var kv in localLabels)
+                {
+                    if (kv.Key.StartsWith(operatorPrefix, StringComparison.Ordinal))
+                        rLb[kv.Key] = kv.Value;
+                }
+            }
+
+            return refetched;
+        }
+
+        /// <summary>
+        /// Bounded-retry helper shared by <see cref="UpdateKubernetesStatus"/> and
+        /// <see cref="UpdateKubernetesMetadata"/>. Issues up to <c>1 +
+        /// KubeConflictRetryDelaysMs.Length</c> total attempts (4 max with the current
+        /// 3-element delay table; the 4th attempt fires after the 1600ms delay if needed).
+        ///
+        /// On <see cref="HttpOperationException"/> with
+        /// <see cref="HttpStatusCode.Conflict"/>: refetch the entity from the API server,
+        /// project the caller's intended mutation onto the refetched object via the
+        /// <paramref name="overlayLocalOntoRefetched"/> callback, and retry.
+        ///
+        /// Any non-409 exception, retry exhaustion, or cancellation propagates unchanged.
+        /// </summary>
+        private async Task<TEntity> UpdateKubernetesWithConflictRetryAsync(
+            TEntity entity,
+            string operation,
+            string writeKind,
+            Func<IKubernetesClient, TEntity, CancellationToken, Task<TEntity>> writeAsync,
+            Func<TEntity, TEntity, TEntity> overlayLocalOntoRefetched,
+            CancellationToken cancellationToken)
+        {
+            var attempt = 0;
+            var maxAttempts = 1 + KubeConflictRetryDelaysMs.Length;
+            var current = entity;
+
+            while (true)
+            {
+                attempt++;
+                try
+                {
+                    return await writeAsync(Kube, current, cancellationToken);
+                }
+                catch (HttpOperationException ex) when (ex.Response?.StatusCode == HttpStatusCode.Conflict && attempt < maxAttempts)
+                {
+                    var delayMs = ComputeKubeConflictRetryDelayMs(attempt);
+
+                    Logger.LogWarningJson(
+                        $"{EntityTypeName} {entity.Namespace()}/{entity.Name()} {writeKind} write conflict (409) on attempt {attempt}/{maxAttempts} after {operation}; refetching and retrying in {delayMs}ms",
+                        new
+                        {
+                            entityTypeName = EntityTypeName,
+                            entityNamespace = entity.Namespace(),
+                            entityName = entity.Name(),
+                            operation,
+                            writeKind,
+                            attempt,
+                            maxAttempts,
+                            retryDelayMs = delayMs,
+                            errorType = "kube_conflict"
+                        });
+
+                    // Delay (cancellable) before refetch + retry. OperationCanceledException
+                    // is allowed to propagate — outer ReconcileAsync catch path handles it.
+                    await Task.Delay(delayMs, cancellationToken);
+
+                    var refetched = await Kube.GetAsync<TEntity>(entity.Name(), entity.Namespace(), cancellationToken);
+                    if (refetched is null)
+                    {
+                        // Entity is gone from the API server — nothing to update. Re-throw
+                        // the original 409 so the outer catch can decide what to do.
+                        throw;
+                    }
+
+                    current = overlayLocalOntoRefetched(current, refetched);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogErrorJson(
+                        $"{EntityTypeName} {entity.Namespace()}/{entity.Name()} failed to update Kubernetes {writeKind} after {operation}: {ex.Message}",
+                        new
+                        {
+                            entityTypeName = EntityTypeName,
+                            entityNamespace = entity.Namespace(),
+                            entityName = entity.Name(),
+                            operation,
+                            writeKind,
+                            attempt,
+                            errorMessage = ex.Message
+                        },
+                        ex);
+                    throw;
+                }
             }
         }
 

--- a/src/Alethic.Auth0.Operator/Program.cs
+++ b/src/Alethic.Auth0.Operator/Program.cs
@@ -18,6 +18,7 @@ namespace Alethic.Auth0.Operator
             var builder = Host.CreateApplicationBuilder(args);
             builder.Services.AddKubernetesOperator().RegisterComponents();
             builder.Services.AddMemoryCache();
+            builder.Services.AddHttpClient();
             builder.Services.Configure<OperatorOptions>(builder.Configuration.GetSection("Auth0:Operator"));
 
             var app = builder.Build();

--- a/src/Alethic.Auth0.Operator/Services/ITenantApiAccess.cs
+++ b/src/Alethic.Auth0.Operator/Services/ITenantApiAccess.cs
@@ -22,5 +22,13 @@ namespace Alethic.Auth0.Operator.Services
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A valid access token</returns>
         Task<string> GetAccessTokenAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Evicts the cached access token, forcing the next <see cref="GetAccessTokenAsync"/> call
+        /// to obtain a fresh token from Auth0. Call this after a server-side rejection (e.g. 401)
+        /// to recover from a token Auth0 considers invalid even though its local expiration has not yet elapsed.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
+        Task InvalidateAccessTokenAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/Alethic.Auth0.Operator/Services/TenantApiAccess.cs
+++ b/src/Alethic.Auth0.Operator/Services/TenantApiAccess.cs
@@ -50,6 +50,21 @@ namespace Alethic.Auth0.Operator.Services
         public Uri BaseUri => _credentials.BaseUri;
 
         /// <inheritdoc />
+        public async Task InvalidateAccessTokenAsync(CancellationToken cancellationToken = default)
+        {
+            await accessTokenSemaphore.WaitAsync(cancellationToken);
+            try
+            {
+                _credentials.AccessToken = null;
+                _credentials.TokenExpiration = null;
+            }
+            finally
+            {
+                accessTokenSemaphore.Release();
+            }
+        }
+
+        /// <inheritdoc />
         public async Task<string> GetAccessTokenAsync(CancellationToken cancellationToken = default)
         {
             await accessTokenSemaphore.WaitAsync(cancellationToken);


### PR DESCRIPTION
## Summary

- Replaces the deprecated `enabled_clients` field on `Connections.UpdateAsync` with the atomic `PATCH /api/v2/connections/{connectionId}/clients` endpoint (`body [{client_id, status: true|false}]`). The previous read-modify-write path returned 404 against prod-US Auth0 and is no longer functional; the new PATCH centralizes membership writes in `V1ClientController.PatchConnectionClientsAsync`.
- Hardens status writes against 409 (bounded retry with refetch + overlay) and always-requeues `V1Controller.ReconcileAsync` on exception, scoped by `IsProgrammerBug` to keep deterministic crash-loops for code-level bugs.
- Adds dedicated test files (758 lines total) covering golden-path enable/disable, 401 retry-with-token-evict, 429 → `RateLimitApiException`, mixed add/remove, and 409 retry on status writes.

## Background

The `enabled_clients` field on `Connection` is deprecated by Auth0 and returns 404 in some Auth0 envs. The atomic `PATCH /connections/{id}/clients` endpoint is the documented replacement; its body shape is `[{ "client_id": "<id>", "status": true|false }]` and it is intrinsically idempotent at the Auth0 side, eliminating the read-modify-write window that the prior implementation had.

## Changes by commit

| SHA | Description |
| --- | --- |
| `a42f357` | Handle the Auth0 `enabled_clients` field deprecation. |
| `c5eaf44` | in progress |
| `e62fe24` | Address MR !1 feedback: single body read, dispose ownership, success log |
| `a67db44` | Switch atomic-membership writes to PATCH /connections/{id}/clients |
| `ae49df0` | Harden status writes against 409 + always requeue on exception |
| `d8b4c91` | Back-fit cherry-picked code to pre-logging-redesign API |
| `406a62e` | Apply LA-RF-81-slim review cleanup (M1, M2, L1-L4) |
| `8d44bed` | Address MR !1 round-3 review feedback (#16, #18) |

## Validation

- **Live golden-path run against prod-US Auth0** (transcript 1.1, executed 2026-05-18 against `mt-mus1-test` partition):
  - Disable PATCH: `PATCH /api/v2/connections/con_djWZRofe74nikrT2/clients` with `[{client_id: ljsu0G9YqxaqyX2rkDPMmBWRTFO4yE9L, status:false}]` → 204, reconcile completed in 977 ms.
  - Enable PATCH: same shape, `status:true` → 204, reconcile completed in 1018 ms.
  - Pre/post Auth0 read-back: 3 → 4 connections (state confirmed in prod).
  - K8s `events.k8s.io/v1` `Normal/Reconcile/Success` emitted by `kubernetes.auth0.com/operator`.
  - 4-element matrix invariant preserved end-to-end (both immutable IDs + both test IDs intact).

## Independent pre-merge review

Two specialist agent reviews ran in parallel against `main..HEAD`:

- **CRD parity**: untouched — `git diff --stat` of `Models/`, `api/`, `config/`, `charts/` is empty.
- **Idempotency**: `ReconcileEnabledConnections` diffs `desired vs. current` (`connectionsToAdd = desired.Except(current)`, `connectionsToRemove = current.Except(desired)`) before emitting any PATCH. Same-state reconciles produce zero PATCH lines — confirmed live.
- **Finalizers, policy gating, DI graph**: untouched / clean.
- **Read-after-write window**: eliminated by atomic PATCH — strict improvement vs. main.

### Architect's primary blocker — invalidated by IL inspection

The architect flagged that `RateLimitApiException` might be swallowed by the broader `catch (ErrorApiException)` at `V1Controller.cs:608` if the latter were a parent class. Verified directly against `Auth0.Core.dll 7.45.1`:

```
ApiException (abstract)         extends System.Exception
ErrorApiException               extends Auth0.Core.Exceptions.ApiException   ← sibling
RateLimitApiException           extends Auth0.Core.Exceptions.ApiException   ← sibling
```

They are siblings, not parent/child. C# `is`-matching means the `ErrorApiException` catch cannot swallow a `RateLimitApiException`. 429 → `X-RateLimit-Reset` honouring intact.

### Bounded observability regression (post-merge follow-up — not blocking)

The new `PatchConnectionClientsAsync` uses raw `HttpClient` (vs. main's `api.Connections.UpdateAsync`). `ThrowFromHttpFailure` maps only 429 → `RateLimitApiException`; 5xx becomes `HttpRequestException` → generic always-requeue. Correctness intact (retries still happen via the requeue path); Events lose tier-1 classification on 5xx. Tracked as a post-merge follow-up on branch `LA-RF-81-followup-logging` along with three other defensive-coding follow-ups (broaden `IsProgrammerBug`, plumb `{ns}/{name}` through PATCH success log, defensive `HasPolicy(Update)` at internal write boundary).

## Test plan

- [x] `dotnet test src/Alethic.Auth0.Operator.Tests/` — all green locally.
- [x] Transcript 1.1 (golden-path enable+disable) — PASS against prod-US Auth0 `mt-mus1-test`.
- [ ] Smoke-test on staging cluster post-merge to confirm KubeOps deployment still rolls cleanly.
- [ ] Watch operator logs for 24h post-deploy for any unexpected always-requeue patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)