### PR TITLE
Add CODEOWNERS file owned by @seatgeek/employees

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-policies/about-code-owners
 #
-# The team-developers team owns the entire repository. Any change to any path
-# requires review from a member of @seatgeek/team-developers.
+# The employees team owns the entire repository. Any change to any path
+# requires review from a member of @seatgeek/employees.
 
-*       @seatgeek/team-developers
+*       @seatgeek/employees

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-policies/about-code-owners
+#
+# The team-developers team owns the entire repository. Any change to any path
+# requires review from a member of @seatgeek/team-developers.
+
+*       @seatgeek/team-developers


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` with a single rule making `@seatgeek/employees` the owner of every path in the repo.
- Enables the **"Require review from Code Owners"** toggle on the existing `main` branch ruleset to take effect — once that toggle is on, every PR targeting `main` will require approval from a member of `@seatgeek/employees`.

## Why

Today the `main` branch ruleset requires 1 approving review, but the approver can be anyone with `push` access to the repo. Adding CODEOWNERS makes the ownership explicit and auditable in-repo.

## Follow-up (post-merge)

After this PR lands, an admin should enable **"Require review from Code Owners"** on the existing ruleset at https://github.com/seatgeek/auth0-operator/rules/7588557 for the rule to start enforcing approvals.

## Test plan

- [ ] Verify the CODEOWNERS file is detected: open this PR and confirm the `@seatgeek/employees` team is automatically requested for review.
- [ ] (Post-merge) After enabling "Require review from Code Owners" on the ruleset, open a follow-up test PR and confirm it is blocked from merging until an `employees` member approves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)