### PR TITLE
Add CODEOWNERS file owned by @seatgeek/employees

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-policies/about-code-owners
+#
+# The employees team owns the entire repository. Any change to any path
+# requires review from a member of @seatgeek/employees.
+
+*       @seatgeek/employees


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` with a single rule making `@seatgeek/employees` the owner of every path in the repo.
- Recreated from #37 to test admin merge-bypass behavior with CODEOWNERS in the PR diff.

## Why

Today the `main` branch ruleset requires 1 approving review, but the approver can be anyone with `push` access to the repo. Adding CODEOWNERS makes ownership explicit and auditable in-repo.

## Follow-up (post-merge)

After this PR lands, an admin should enable **"Require review from Code Owners"** on the existing ruleset at https://github.com/seatgeek/auth0-operator/rules/7588557 for the rule to start enforcing approvals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)