### PR TITLE
Remove CODEOWNERS until a Visible team is available

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,0 @@
-# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-policies/about-code-owners
-#
-# The employees team owns the entire repository. Any change to any path
-# requires review from a member of @seatgeek/employees.
-
-*       @seatgeek/employees


### PR DESCRIPTION
## Summary

Removes `.github/CODEOWNERS`.

## Why

The owner specified in the file — `@seatgeek/employees` — is a **Secret** team. GitHub's CODEOWNERS resolver rejects Secret teams with:

> Unknown owner on line 6: make sure the team @seatgeek/employees exists, is publicly visible, and has write access to the repository

Because the resolver can't bind any pattern to a valid owner, no path in the repo currently has an enforceable code-owner. Removing the file restores the pre-#37 merge behavior (just the existing ruleset's "1 approving review" rule) and avoids leaving a broken file in `main`.

## Follow-up

Once one of the following is true, re-introduce a CODEOWNERS file:

- An org owner flips `@seatgeek/employees` to **Visible**, or
- A new repo-scoped **Visible** team is created (e.g. `@seatgeek/auth0-operator-codeowners`) with Write access on this repo.

## Test plan

- [ ] After merge, open a follow-up no-op PR and confirm GitHub no longer auto-requests a code-owner team and no longer surfaces the CODEOWNERS error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)