### PR TITLE
Address internal review on LA-RF-81 followup logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -258,5 +258,5 @@ ModelManifest.xml
 Dockerfile.local
 
 # Claude
-.claude/settings.local.json
+.claude/
 claude/tasks/

--- a/src/Alethic.Auth0.Operator.Tests/Controllers/LogAuth0ApiCallTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Controllers/LogAuth0ApiCallTests.cs
@@ -22,22 +22,29 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Alethic.Auth0.Operator.Tests.Controllers
 {
     /// <summary>
-    /// Locks the contract of <see cref="V1Controller{TEntity,TSpec,TStatus,TConf}.LogAuth0ApiCall"/>:
+    /// Locks the contract of the Auth0 API logging funnel
+    /// (<see cref="V1Controller{TEntity,TSpec,TStatus,TConf}.LogAuth0Read"/> and
+    /// <see cref="V1Controller{TEntity,TSpec,TStatus,TConf}.LogAuth0Write"/>):
     ///
     /// R1 — exactly one log entry per call, at the right level (Warning for Write, Information for Read).
     /// R2 — Write calls carry <c>reconciliationType</c> / <c>driftReason</c> / <c>driftFields[]</c>
-    ///      derived from a required <see cref="DriftLogContext"/>; Read calls omit them; passing a
-    ///      null context for a Write is a programmer error that throws at runtime.
+    ///      derived from a required <see cref="DriftLogContext"/>; Read calls omit them. The
+    ///      "Write without context" failure mode is now a compile error (non-nullable parameter on
+    ///      <c>LogAuth0Write</c>) so the runtime-throw test that lived here was retired.
     /// </summary>
     [TestClass]
     public class LogAuth0ApiCallTests
     {
         // V1ClientController is the most fully-wired concrete controller in the test bench, so we
-        // reuse it to reach the protected LogAuth0ApiCall via reflection rather than building a
-        // throwaway controller hierarchy just for this test class.
-        private static readonly MethodInfo _logMethod = typeof(V1ClientController)
-            .GetMethod("LogAuth0ApiCall", BindingFlags.Instance | BindingFlags.NonPublic)
-            ?? throw new InvalidOperationException("LogAuth0ApiCall not found on V1ClientController");
+        // reuse it to reach the protected LogAuth0Read / LogAuth0Write methods via reflection
+        // rather than building a throwaway controller hierarchy just for this test class.
+        private static readonly MethodInfo _logReadMethod = typeof(V1ClientController)
+            .GetMethod("LogAuth0Read", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("LogAuth0Read not found on V1ClientController");
+
+        private static readonly MethodInfo _logWriteMethod = typeof(V1ClientController)
+            .GetMethod("LogAuth0Write", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("LogAuth0Write not found on V1ClientController");
 
         // --- R1: exactly-one-log per call, correct level ---
 
@@ -62,6 +69,39 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
 
             Assert.AreEqual(1, logger.Entries.Count, "Write call must emit exactly one log entry (regression for duplicate-log bug)");
             Assert.AreEqual(LogLevel.Warning, logger.Entries[0].Level);
+        }
+
+        // --- R2: write-log enum fields serialize as camelCase strings, never numbers ---
+        // Locks the [JsonConverter(CamelCaseJsonStringEnumConverter)] contract on
+        // ReconciliationType / DriftChangeType. If someone changes _structuredLogJsonOptions to
+        // install a default JsonStringEnumConverter (or drops the boxing-as-object? step in
+        // EmitAuth0ApiLog), the enums would silently revert to numeric output and every Datadog
+        // dashboard keyed on "drift" / "first" / "finalizer" / "added" / "modified" / "removed"
+        // would go dark. This test fails noisily before that ships.
+
+        [TestMethod]
+        public void WriteCall_ReconciliationType_IsCamelCaseString_NotNumber()
+        {
+            var (controller, logger) = BuildController();
+            var ctx = DriftLogContext.Drift(new List<DriftField>
+            {
+                new("name", DriftChangeType.Modified, BeforeValue: "\"old\"", AfterValue: "\"new\""),
+            });
+
+            Invoke(controller, "msg", Auth0ApiCallType.Write, "A0Client", "n", "ns", "update_client", driftContext: ctx);
+
+            using var doc = JsonDocument.Parse(logger.Entries.Single().Message);
+            var root = doc.RootElement;
+
+            var reconciliationType = root.GetProperty("reconciliationType");
+            Assert.AreEqual(JsonValueKind.String, reconciliationType.ValueKind,
+                "reconciliationType must serialize as a camelCase string, not a number");
+            Assert.AreEqual("drift", reconciliationType.GetString());
+
+            var changeType = root.GetProperty("driftFields")[0].GetProperty("changeType");
+            Assert.AreEqual(JsonValueKind.String, changeType.ValueKind,
+                "driftFields[].changeType must serialize as a camelCase string, not a number");
+            Assert.AreEqual("modified", changeType.GetString());
         }
 
         // --- R2: write-log carries reconciliationType / driftReason / driftFields ---
@@ -158,24 +198,12 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
             Assert.IsFalse(root.TryGetProperty("driftFields", out _), "Read calls must not emit driftFields");
         }
 
-        // --- R2 enforcement: programmer error to write without context ---
-
-        [TestMethod]
-        public void WriteCall_WithoutDriftContext_ThrowsArgumentNullException()
-        {
-            var (controller, _) = BuildController();
-
-            try
-            {
-                Invoke(controller, "msg", Auth0ApiCallType.Write, "A0Client", "n", "ns", "create_client", driftContext: null);
-                Assert.Fail("Expected ArgumentNullException for Write without DriftLogContext");
-            }
-            catch (TargetInvocationException tex)
-            {
-                Assert.IsInstanceOfType<ArgumentNullException>(tex.InnerException,
-                    "Inner exception should be ArgumentNullException, was " + tex.InnerException?.GetType().Name);
-            }
-        }
+        // --- R2 enforcement: "Write without context" is now a compile error ---
+        // The previous WriteCall_WithoutDriftContext_ThrowsArgumentNullException test enforced the
+        // contract at runtime against a single LogAuth0ApiCall(...) entry point. The split into
+        // LogAuth0Read / LogAuth0Write moves that enforcement into the type system: the Write
+        // method's driftContext parameter is non-nullable, so passing null is rejected by the C#
+        // compiler. There is no longer a runtime path to test.
 
         // --- R2 success-counterpart log on IssueAtomicMembershipChangeAsync ---
 
@@ -207,7 +235,8 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
 
             var df = root.GetProperty("driftFields");
             Assert.AreEqual(1, df.GetArrayLength());
-            Assert.AreEqual("spec.conf.enabled_connections[con_x]", df[0].GetProperty("fieldPath").GetString());
+            Assert.AreEqual("spec.conf.enabled_connections", df[0].GetProperty("fieldPath").GetString());
+            Assert.AreEqual("con_x", df[0].GetProperty("afterValue").GetString());
             Assert.AreEqual("added", df[0].GetProperty("changeType").GetString());
         }
 
@@ -262,10 +291,24 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
         private static void Invoke(V1ClientController controller, string message, Auth0ApiCallType type,
             string entityType, string entityName, string entityNamespace, string purpose, DriftLogContext? driftContext)
         {
-            _logMethod.Invoke(controller, new object?[]
+            if (type == Auth0ApiCallType.Write)
             {
-                message, type, entityType, entityName, entityNamespace, purpose, driftContext,
-            });
+                if (driftContext is null)
+                    throw new ArgumentNullException(nameof(driftContext),
+                        "LogAuth0Write is a non-nullable contract; tests must pass a DriftLogContext.");
+
+                _logWriteMethod.Invoke(controller, new object?[]
+                {
+                    message, entityType, entityName, entityNamespace, purpose, driftContext,
+                });
+            }
+            else
+            {
+                _logReadMethod.Invoke(controller, new object?[]
+                {
+                    message, entityType, entityName, entityNamespace, purpose,
+                });
+            }
         }
 
         private static (V1ClientController, RecordingLogger) BuildController()

--- a/src/Alethic.Auth0.Operator.Tests/Controllers/LogAuth0ApiCallTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Controllers/LogAuth0ApiCallTests.cs
@@ -1,0 +1,341 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Alethic.Auth0.Operator.Controllers;
+using Alethic.Auth0.Operator.Options;
+using Alethic.Auth0.Operator.Services;
+
+using KubeOps.Abstractions.Queue;
+using KubeOps.KubernetesClient;
+
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Alethic.Auth0.Operator.Tests.Controllers
+{
+    /// <summary>
+    /// Locks the contract of <see cref="V1Controller{TEntity,TSpec,TStatus,TConf}.LogAuth0ApiCall"/>:
+    ///
+    /// R1 — exactly one log entry per call, at the right level (Warning for Write, Information for Read).
+    /// R2 — Write calls carry <c>reconciliationType</c> / <c>driftReason</c> / <c>driftFields[]</c>
+    ///      derived from a required <see cref="DriftLogContext"/>; Read calls omit them; passing a
+    ///      null context for a Write is a programmer error that throws at runtime.
+    /// </summary>
+    [TestClass]
+    public class LogAuth0ApiCallTests
+    {
+        // V1ClientController is the most fully-wired concrete controller in the test bench, so we
+        // reuse it to reach the protected LogAuth0ApiCall via reflection rather than building a
+        // throwaway controller hierarchy just for this test class.
+        private static readonly MethodInfo _logMethod = typeof(V1ClientController)
+            .GetMethod("LogAuth0ApiCall", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("LogAuth0ApiCall not found on V1ClientController");
+
+        // --- R1: exactly-one-log per call, correct level ---
+
+        [TestMethod]
+        public void ReadCall_EmitsExactlyOneEntry_AtInformationLevel()
+        {
+            var (controller, logger) = BuildController();
+
+            Invoke(controller, "test read", Auth0ApiCallType.Read, "A0Client", "n", "ns", "p", driftContext: null);
+
+            Assert.AreEqual(1, logger.Entries.Count, "Read call must emit exactly one log entry");
+            Assert.AreEqual(LogLevel.Information, logger.Entries[0].Level);
+        }
+
+        [TestMethod]
+        public void WriteCall_EmitsExactlyOneEntry_AtWarningLevel()
+        {
+            var (controller, logger) = BuildController();
+
+            Invoke(controller, "test write", Auth0ApiCallType.Write, "A0Client", "n", "ns", "create_client",
+                driftContext: DriftLogContext.FirstReconciliation());
+
+            Assert.AreEqual(1, logger.Entries.Count, "Write call must emit exactly one log entry (regression for duplicate-log bug)");
+            Assert.AreEqual(LogLevel.Warning, logger.Entries[0].Level);
+        }
+
+        // --- R2: write-log carries reconciliationType / driftReason / driftFields ---
+
+        [TestMethod]
+        public void WriteCall_DriftPath_SerializesModifiedAndRemovedFields()
+        {
+            var (controller, logger) = BuildController();
+            var fields = new List<DriftField>
+            {
+                new("name", DriftChangeType.Modified, BeforeValue: "\"old\"", AfterValue: "\"new\""),
+                new("description", DriftChangeType.Modified, BeforeValue: "\"a\"", AfterValue: "\"b\""),
+                new("enabled_clients", DriftChangeType.Removed, BeforeValue: "[...]", AfterValue: null),
+            };
+            var ctx = DriftLogContext.Drift(fields);
+
+            Invoke(controller, "msg", Auth0ApiCallType.Write, "A0Connection", "n", "ns", "update_connection", driftContext: ctx);
+
+            using var doc = JsonDocument.Parse(logger.Entries.Single().Message);
+            var root = doc.RootElement;
+            Assert.AreEqual("drift", root.GetProperty("reconciliationType").GetString());
+            Assert.AreEqual("0 added, 2 modified, 1 removed", root.GetProperty("driftReason").GetString());
+
+            var df = root.GetProperty("driftFields");
+            Assert.AreEqual(3, df.GetArrayLength());
+            Assert.AreEqual("name", df[0].GetProperty("fieldPath").GetString());
+            Assert.AreEqual("modified", df[0].GetProperty("changeType").GetString());
+            Assert.AreEqual("\"old\"", df[0].GetProperty("beforeValue").GetString());
+            Assert.AreEqual("\"new\"", df[0].GetProperty("afterValue").GetString());
+
+            Assert.AreEqual("removed", df[2].GetProperty("changeType").GetString());
+            Assert.AreEqual(JsonValueKind.Null, df[2].GetProperty("afterValue").ValueKind);
+        }
+
+        [TestMethod]
+        public void WriteCall_DriftPath_SerializesAddedField_BeforeIsNull()
+        {
+            var (controller, logger) = BuildController();
+            var ctx = DriftLogContext.Drift(new List<DriftField>
+            {
+                new("new_field", DriftChangeType.Added, BeforeValue: null, AfterValue: "\"hello\""),
+            });
+
+            Invoke(controller, "msg", Auth0ApiCallType.Write, "A0Connection", "n", "ns", "update_connection", driftContext: ctx);
+
+            using var doc = JsonDocument.Parse(logger.Entries.Single().Message);
+            var df = doc.RootElement.GetProperty("driftFields");
+            Assert.AreEqual("added", df[0].GetProperty("changeType").GetString());
+            Assert.AreEqual(JsonValueKind.Null, df[0].GetProperty("beforeValue").ValueKind);
+            Assert.AreEqual("\"hello\"", df[0].GetProperty("afterValue").GetString());
+        }
+
+        [TestMethod]
+        public void WriteCall_FirstReconciliation_EmptyDrift_DescriptiveReason()
+        {
+            var (controller, logger) = BuildController();
+
+            Invoke(controller, "msg", Auth0ApiCallType.Write, "A0Client", "n", "ns", "create_client",
+                driftContext: DriftLogContext.FirstReconciliation());
+
+            using var doc = JsonDocument.Parse(logger.Entries.Single().Message);
+            var root = doc.RootElement;
+            Assert.AreEqual("first", root.GetProperty("reconciliationType").GetString());
+            Assert.AreEqual(0, root.GetProperty("driftFields").GetArrayLength());
+            StringAssert.Contains(root.GetProperty("driftReason").GetString()!, "first reconciliation");
+        }
+
+        [TestMethod]
+        public void WriteCall_Finalizer_EmptyDrift_DescriptiveReason()
+        {
+            var (controller, logger) = BuildController();
+
+            Invoke(controller, "msg", Auth0ApiCallType.Write, "A0Client", "n", "ns", "delete_client",
+                driftContext: DriftLogContext.FinalizerDelete());
+
+            using var doc = JsonDocument.Parse(logger.Entries.Single().Message);
+            var root = doc.RootElement;
+            Assert.AreEqual("finalizer", root.GetProperty("reconciliationType").GetString());
+            Assert.AreEqual(0, root.GetProperty("driftFields").GetArrayLength());
+            StringAssert.Contains(root.GetProperty("driftReason").GetString()!, "kubernetes entity deleted");
+        }
+
+        [TestMethod]
+        public void ReadCall_OmitsDriftFields()
+        {
+            var (controller, logger) = BuildController();
+
+            Invoke(controller, "msg", Auth0ApiCallType.Read, "A0Client", "n", "ns", "get_client", driftContext: null);
+
+            using var doc = JsonDocument.Parse(logger.Entries.Single().Message);
+            var root = doc.RootElement;
+            Assert.IsFalse(root.TryGetProperty("reconciliationType", out _), "Read calls must not emit reconciliationType");
+            Assert.IsFalse(root.TryGetProperty("driftReason", out _), "Read calls must not emit driftReason");
+            Assert.IsFalse(root.TryGetProperty("driftFields", out _), "Read calls must not emit driftFields");
+        }
+
+        // --- R2 enforcement: programmer error to write without context ---
+
+        [TestMethod]
+        public void WriteCall_WithoutDriftContext_ThrowsArgumentNullException()
+        {
+            var (controller, _) = BuildController();
+
+            try
+            {
+                Invoke(controller, "msg", Auth0ApiCallType.Write, "A0Client", "n", "ns", "create_client", driftContext: null);
+                Assert.Fail("Expected ArgumentNullException for Write without DriftLogContext");
+            }
+            catch (TargetInvocationException tex)
+            {
+                Assert.IsInstanceOfType<ArgumentNullException>(tex.InnerException,
+                    "Inner exception should be ArgumentNullException, was " + tex.InnerException?.GetType().Name);
+            }
+        }
+
+        // --- R2 success-counterpart log on IssueAtomicMembershipChangeAsync ---
+
+        [TestMethod]
+        public async Task EnableClient_PreWriteLog_GoesThroughLogAuth0ApiCallWriteFunnel()
+        {
+            // Every membership-change write must show up in the central LogAuth0ApiCall(Write,...)
+            // funnel so it counts in Datadog's @auth0ApiCallType:write tally and carries the
+            // canonical DriftLogContext payload shape. The post-success info-log is the outcome
+            // marker only — drift context lives on the pre-write entry as the single source of truth.
+            var handler = new SingleResponseHandler((_, __) =>
+                new HttpResponseMessage(HttpStatusCode.Created) { Content = new StringContent("") });
+            var logger = new RecordingLogger();
+            var controller = BuildClientControllerForMembership(handler, logger);
+
+            await controller.EnableClientOnConnectionAsync(new FakeTenantApiAccess(), "con_x", "client_x",
+                "default", "test-client", CancellationToken.None);
+
+            var writeEntry = logger.Entries
+                .FirstOrDefault(e => e.Level == LogLevel.Warning && e.Message.Contains("\"auth0ApiCallType\":\"write\""));
+            Assert.AreNotEqual(default, writeEntry, "Expected a pre-write Warning entry from LogAuth0ApiCall for the membership change");
+
+            using var doc = JsonDocument.Parse(writeEntry.Message);
+            var root = doc.RootElement;
+            Assert.AreEqual("write", root.GetProperty("auth0ApiCallType").GetString());
+            Assert.AreEqual("enable_client_on_connection", root.GetProperty("auth0ApiCallPurpose").GetString());
+            Assert.AreEqual("drift", root.GetProperty("reconciliationType").GetString());
+            StringAssert.Contains(root.GetProperty("driftReason").GetString()!, "enable con_x");
+
+            var df = root.GetProperty("driftFields");
+            Assert.AreEqual(1, df.GetArrayLength());
+            Assert.AreEqual("spec.conf.enabled_connections[con_x]", df[0].GetProperty("fieldPath").GetString());
+            Assert.AreEqual("added", df[0].GetProperty("changeType").GetString());
+        }
+
+        [TestMethod]
+        public async Task EnableClient_SuccessLog_IsOutcomeOnly_DoesNotDuplicateDriftPayload()
+        {
+            var handler = new SingleResponseHandler((_, __) =>
+                new HttpResponseMessage(HttpStatusCode.Created) { Content = new StringContent("") });
+            var logger = new RecordingLogger();
+            var controller = BuildClientControllerForMembership(handler, logger);
+
+            await controller.EnableClientOnConnectionAsync(new FakeTenantApiAccess(), "con_x", "client_x",
+                "default", "test-client", CancellationToken.None);
+
+            var successMsg = logger.Entries.Select(e => e.Message)
+                .FirstOrDefault(m => m.Contains("\"operation\":\"enable_client_on_connection\"") && m.Contains("succeeded"));
+            Assert.IsNotNull(successMsg, "Expected the structured success-log for enable_client_on_connection");
+
+            using var doc = JsonDocument.Parse(successMsg!);
+            var root = doc.RootElement;
+            Assert.AreEqual("enable_client_on_connection", root.GetProperty("operation").GetString());
+            // Drift payload now lives on the pre-write LogAuth0ApiCall entry — must not be duplicated here.
+            Assert.IsFalse(root.TryGetProperty("driftFields", out _), "Success log must not duplicate driftFields");
+            Assert.IsFalse(root.TryGetProperty("driftReason", out _), "Success log must not duplicate driftReason");
+            Assert.IsFalse(root.TryGetProperty("reconciliationType", out _), "Success log must not duplicate reconciliationType");
+        }
+
+        [TestMethod]
+        public async Task DisableClient_PreWriteLog_GoesThroughLogAuth0ApiCallWriteFunnel()
+        {
+            var handler = new SingleResponseHandler((_, __) =>
+                new HttpResponseMessage(HttpStatusCode.NoContent));
+            var logger = new RecordingLogger();
+            var controller = BuildClientControllerForMembership(handler, logger);
+
+            await controller.DisableClientOnConnectionAsync(new FakeTenantApiAccess(), "con_y", "client_y",
+                "default", "test-client", CancellationToken.None);
+
+            var writeEntry = logger.Entries
+                .FirstOrDefault(e => e.Level == LogLevel.Warning && e.Message.Contains("\"auth0ApiCallType\":\"write\""));
+            Assert.AreNotEqual(default, writeEntry, "Expected a pre-write Warning entry from LogAuth0ApiCall for the membership change");
+
+            using var doc = JsonDocument.Parse(writeEntry.Message);
+            var root = doc.RootElement;
+            Assert.AreEqual("disable_client_on_connection", root.GetProperty("auth0ApiCallPurpose").GetString());
+            var df = root.GetProperty("driftFields");
+            Assert.AreEqual("removed", df[0].GetProperty("changeType").GetString());
+        }
+
+        // --- helpers ---
+
+        private static void Invoke(V1ClientController controller, string message, Auth0ApiCallType type,
+            string entityType, string entityName, string entityNamespace, string purpose, DriftLogContext? driftContext)
+        {
+            _logMethod.Invoke(controller, new object?[]
+            {
+                message, type, entityType, entityName, entityNamespace, purpose, driftContext,
+            });
+        }
+
+        private static (V1ClientController, RecordingLogger) BuildController()
+        {
+            var logger = new RecordingLogger();
+            return (BuildClientControllerForMembership(
+                new SingleResponseHandler((_, __) => new HttpResponseMessage(HttpStatusCode.OK)),
+                logger), logger);
+        }
+
+        private static V1ClientController BuildClientControllerForMembership(HttpMessageHandler handler, ILogger<V1ClientController> logger)
+        {
+            var factory = new SingleHandlerHttpClientFactory(handler);
+            var kube = System.Reflection.DispatchProxy.Create<IKubernetesClient, ThrowingKubeProxy>();
+            return new V1ClientController(
+                kube: kube,
+                requeue: (EntityRequeue<Alethic.Auth0.Operator.Models.V1Client>)((_, _) => { }),
+                cache: new MemoryCache(new MemoryCacheOptions()),
+                logger: logger,
+                options: Microsoft.Extensions.Options.Options.Create(new OperatorOptions()),
+                httpClientFactory: factory);
+        }
+
+        internal sealed class RecordingLogger : ILogger<V1ClientController>
+        {
+            public List<(LogLevel Level, string Message)> Entries { get; } = new();
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                Entries.Add((logLevel, formatter(state, exception)));
+            }
+            private sealed class NullScope : IDisposable
+            {
+                public static readonly NullScope Instance = new();
+                public void Dispose() { }
+            }
+        }
+
+        public class ThrowingKubeProxy : System.Reflection.DispatchProxy
+        {
+            protected override object? Invoke(MethodInfo? targetMethod, object?[]? args) =>
+                throw new InvalidOperationException(
+                    $"IKubernetesClient.{targetMethod?.Name} was unexpectedly invoked.");
+        }
+
+        private sealed class SingleHandlerHttpClientFactory : IHttpClientFactory
+        {
+            private readonly HttpMessageHandler _handler;
+            public SingleHandlerHttpClientFactory(HttpMessageHandler handler) => _handler = handler;
+            public HttpClient CreateClient(string name) => new HttpClient(_handler, disposeHandler: false);
+        }
+
+        private sealed class SingleResponseHandler : HttpMessageHandler
+        {
+            private readonly Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> _responder;
+            public SingleResponseHandler(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> responder)
+            {
+                _responder = responder;
+            }
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+                => Task.FromResult(_responder(request, cancellationToken));
+        }
+
+        private sealed class FakeTenantApiAccess : ITenantApiAccess
+        {
+            public Uri BaseUri => new Uri("https://example.us.auth0.com/api/v2/");
+            public Task<string> GetAccessTokenAsync(CancellationToken cancellationToken = default) => Task.FromResult("fake-token");
+            public Task InvalidateAccessTokenAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        }
+    }
+}

--- a/src/Alethic.Auth0.Operator.Tests/Controllers/LogValueFormatterTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Controllers/LogValueFormatterTests.cs
@@ -37,6 +37,35 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
             StringAssert.Contains(result, "(total: 7 items)");
         }
 
+        // R3 regression coverage: the IsSensitiveKey "token" rule must match OAuth secret tokens
+        // (access_token / refresh_token / id_token) without over-matching legitimate non-secret
+        // fields whose names start with "token_" (token_endpoint, token_endpoint_auth_method) or
+        // contain "_token_" as a non-secret segment (access_token_lifetime_in_seconds).
+        [DataTestMethod]
+        [DataRow("access_token")]
+        [DataRow("refresh_token")]
+        [DataRow("id_token")]
+        [DataRow("client_assertion")]
+        [DataRow("client_assertion_signing_key")]
+        [DataRow("signing_key")]
+        [DataRow("certificate")]
+        [DataRow("pfx")]
+        public void IsSensitiveKey_RedactsSecretShapedKey(string key)
+        {
+            Assert.IsTrue(LogValueFormatter.IsSensitiveKey(key),
+                $"Expected IsSensitiveKey(\"{key}\") to be true — secret-shaped key must redact.");
+        }
+
+        [DataTestMethod]
+        [DataRow("token_endpoint")]
+        [DataRow("token_endpoint_auth_method")]
+        [DataRow("access_token_lifetime_in_seconds")]
+        public void IsSensitiveKey_DoesNotRedactNonSecretTokenNamedKey(string key)
+        {
+            Assert.IsFalse(LogValueFormatter.IsSensitiveKey(key),
+                $"Expected IsSensitiveKey(\"{key}\") to be false — non-secret config key must not redact.");
+        }
+
         /// <summary>
         /// Single-pass <see cref="IEnumerable"/> test helper. Throws on the second
         /// <see cref="GetEnumerator"/> call so any double-enumeration in production code fails fast.

--- a/src/Alethic.Auth0.Operator.Tests/Controllers/LogValueFormatterTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Controllers/LogValueFormatterTests.cs
@@ -1,0 +1,63 @@
+using System.Collections;
+using System.Collections.Generic;
+
+using Alethic.Auth0.Operator.Controllers;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Alethic.Auth0.Operator.Tests.Controllers
+{
+    /// <summary>
+    /// Locks the materialize-once contract on
+    /// <see cref="LogValueFormatter.FormatValueForLogging"/> for the <c>IEnumerable</c> branch.
+    /// Previous implementation called <c>.Take(5).Select(...)</c> and <c>.Count()</c> on the same
+    /// source, which re-enumerates lazy / one-shot enumerables. Regression-locked via
+    /// <see cref="OneShotEnumerable"/>, which throws if its <c>GetEnumerator()</c> is called twice.
+    /// </summary>
+    [TestClass]
+    public class LogValueFormatterTests
+    {
+        [TestMethod]
+        public void FormatValueForLogging_IEnumerable_EnumeratesSourceOnlyOnce()
+        {
+            var source = new OneShotEnumerable(new object[] { "a", "b", "c" });
+
+            var result = LogValueFormatter.FormatValueForLogging(source);
+
+            Assert.AreEqual("[\"a\", \"b\", \"c\"]", result);
+        }
+
+        [TestMethod]
+        public void FormatValueForLogging_IEnumerable_OverFiveItems_EnumeratesSourceOnlyOnce()
+        {
+            var source = new OneShotEnumerable(new object[] { 1, 2, 3, 4, 5, 6, 7 });
+
+            var result = LogValueFormatter.FormatValueForLogging(source);
+
+            StringAssert.Contains(result, "(total: 7 items)");
+        }
+
+        /// <summary>
+        /// Single-pass <see cref="IEnumerable"/> test helper. Throws on the second
+        /// <see cref="GetEnumerator"/> call so any double-enumeration in production code fails fast.
+        /// </summary>
+        private sealed class OneShotEnumerable : IEnumerable
+        {
+            private readonly IEnumerable _inner;
+            private bool _enumerated;
+
+            public OneShotEnumerable(IEnumerable inner)
+            {
+                _inner = inner;
+            }
+
+            public IEnumerator GetEnumerator()
+            {
+                if (_enumerated)
+                    Assert.Fail("OneShotEnumerable enumerated more than once — caller is double-enumerating the source.");
+                _enumerated = true;
+                return _inner.GetEnumerator();
+            }
+        }
+    }
+}

--- a/src/Alethic.Auth0.Operator.Tests/Controllers/V1ClientControllerEnabledConnectionsTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Controllers/V1ClientControllerEnabledConnectionsTests.cs
@@ -35,6 +35,8 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
         private const string TenantBaseUri = "https://example.us.auth0.com/api/v2/";
         private const string ConnectionId = "con_test123";
         private const string ClientId = "abc_clientid";
+        private const string EntityNamespace = "default";
+        private const string EntityName = "test-client";
 
         // ---- Golden path: enable issues PATCH with status:true and 204 clears ----
 
@@ -46,7 +48,7 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
             var tenant = new FakeTenantApiAccess();
 
             await controller.EnableClientOnConnectionAsync(tenant, ConnectionId, ClientId,
-                defaultNamespace: "default", CancellationToken.None);
+                EntityNamespace, EntityName, CancellationToken.None);
 
             Assert.AreEqual(1, handler.Requests.Count);
             var req = handler.Requests[0];
@@ -70,15 +72,20 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
             var controller = BuildController(handler, logger);
 
             await controller.EnableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
-                defaultNamespace: "default", CancellationToken.None);
+                EntityNamespace, EntityName, CancellationToken.None);
 
             var hit = logger.Messages.SingleOrDefault(m =>
                 m.Contains("\"operation\":\"enable_client_on_connection\"")
                 && m.Contains("succeeded")
                 && m.Contains($"\"connectionId\":\"{ConnectionId}\"")
-                && m.Contains($"\"clientId\":\"{ClientId}\""));
+                && m.Contains($"\"clientId\":\"{ClientId}\"")
+                && m.Contains($"\"entityNamespace\":\"{EntityNamespace}\"")
+                && m.Contains($"\"entityName\":\"{EntityName}\"")
+                && m.Contains($"{EntityNamespace}/{EntityName}"));
             Assert.IsNotNull(hit,
-                "Expected a structured info log carrying the operation label, success phrasing, and the connection/client pair.\n"
+                "Expected a structured info log carrying the operation label, success phrasing, "
+                + "the connection/client pair, and the K8s entity namespace/name in both the literal "
+                + "message and the structured payload (CR-5).\n"
                 + "Captured messages:\n  - " + string.Join("\n  - ", logger.Messages));
         }
 
@@ -90,15 +97,19 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
             var controller = BuildController(handler, logger);
 
             await controller.DisableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
-                defaultNamespace: "default", CancellationToken.None);
+                EntityNamespace, EntityName, CancellationToken.None);
 
             var hit = logger.Messages.SingleOrDefault(m =>
                 m.Contains("\"operation\":\"disable_client_on_connection\"")
                 && m.Contains("succeeded")
                 && m.Contains($"\"connectionId\":\"{ConnectionId}\"")
-                && m.Contains($"\"clientId\":\"{ClientId}\""));
+                && m.Contains($"\"clientId\":\"{ClientId}\"")
+                && m.Contains($"\"entityNamespace\":\"{EntityNamespace}\"")
+                && m.Contains($"\"entityName\":\"{EntityName}\"")
+                && m.Contains($"{EntityNamespace}/{EntityName}"));
             Assert.IsNotNull(hit,
-                "Expected a structured info log carrying the operation label and success phrasing for the disable path.\n"
+                "Expected a structured info log carrying the operation label, success phrasing, "
+                + "and the K8s entity namespace/name (CR-5) for the disable path.\n"
                 + "Captured messages:\n  - " + string.Join("\n  - ", logger.Messages));
         }
 
@@ -111,7 +122,7 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
             var controller = BuildController(handler);
 
             await controller.DisableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
-                defaultNamespace: "default", CancellationToken.None);
+                EntityNamespace, EntityName, CancellationToken.None);
 
             Assert.AreEqual(1, handler.Requests.Count);
             var req = handler.Requests[0];
@@ -131,9 +142,9 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
                 { Content = new StringContent("{\"statusCode\":400,\"error\":\"Bad Request\"}") });
             var controller = BuildController(handler);
 
-            await Assert.ThrowsExceptionAsync<HttpRequestException>(() =>
+            await Assert.ThrowsExceptionAsync<global::Auth0.Core.Exceptions.ErrorApiException>(() =>
                 controller.EnableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
-                    defaultNamespace: "default", CancellationToken.None));
+                    EntityNamespace, EntityName, CancellationToken.None));
         }
 
         [TestMethod]
@@ -143,9 +154,9 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
                 { Content = new StringContent("{\"statusCode\":403,\"error\":\"Forbidden\"}") });
             var controller = BuildController(handler);
 
-            await Assert.ThrowsExceptionAsync<HttpRequestException>(() =>
+            await Assert.ThrowsExceptionAsync<global::Auth0.Core.Exceptions.ErrorApiException>(() =>
                 controller.DisableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
-                    defaultNamespace: "default", CancellationToken.None));
+                    EntityNamespace, EntityName, CancellationToken.None));
         }
 
         // ---- 401 triggers token regeneration and a single retry ----
@@ -165,7 +176,7 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
             var tenant = new FakeTenantApiAccess { TokenSequence = new[] { "tok-1", "tok-2" } };
 
             await controller.EnableClientOnConnectionAsync(tenant, ConnectionId, ClientId,
-                defaultNamespace: "default", CancellationToken.None);
+                EntityNamespace, EntityName, CancellationToken.None);
 
             Assert.AreEqual(2, handler.Requests.Count, "Should retry once after 401");
             Assert.AreEqual("tok-1", handler.Requests[0].Authorization);
@@ -183,9 +194,30 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
                 { Content = new StringContent("{\"statusCode\":500,\"error\":\"server\"}") });
             var controller = BuildController(handler);
 
-            await Assert.ThrowsExceptionAsync<HttpRequestException>(() =>
+            await Assert.ThrowsExceptionAsync<global::Auth0.Core.Exceptions.ErrorApiException>(() =>
                 controller.EnableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
-                    defaultNamespace: "default", CancellationToken.None));
+                    EntityNamespace, EntityName, CancellationToken.None));
+        }
+
+        // ---- CR-1: 5xx populates ErrorApiException with status code + ApiError so the tier-1
+        //      catch (V1Controller.cs:608) reads the body verbatim instead of the generic catch
+        //      at V1Controller.cs:738 emitting an "Unknown error" Event. ----
+
+        [TestMethod]
+        public async Task EnableClientOnConnection_503_Throws_ErrorApiException_With_StatusCode_And_ApiError()
+        {
+            var handler = new RecordingHandler((_, __) => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                { Content = new StringContent("{\"statusCode\":503,\"error\":\"Service Unavailable\",\"message\":\"upstream down\"}") });
+            var controller = BuildController(handler);
+
+            var ex = await Assert.ThrowsExceptionAsync<global::Auth0.Core.Exceptions.ErrorApiException>(() =>
+                controller.EnableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
+                    EntityNamespace, EntityName, CancellationToken.None));
+
+            Assert.AreEqual(HttpStatusCode.ServiceUnavailable, ex.StatusCode,
+                "503 must surface as ErrorApiException.StatusCode = 503 so the tier-1 catch (V1Controller.cs:608) labels the Event correctly.");
+            Assert.IsNotNull(ex.ApiError, "ApiError must be populated from the body");
+            Assert.AreEqual("upstream down", ex.ApiError!.Message);
         }
 
         // ---- 429 is surfaced as Auth0.Core.Exceptions.RateLimitApiException so the upstream
@@ -209,7 +241,7 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
 
             var ex = await Assert.ThrowsExceptionAsync<global::Auth0.Core.Exceptions.RateLimitApiException>(() =>
                 controller.DisableClientOnConnectionAsync(new FakeTenantApiAccess(), ConnectionId, ClientId,
-                    defaultNamespace: "default", CancellationToken.None));
+                    EntityNamespace, EntityName, CancellationToken.None));
 
             Assert.IsNotNull(ex.RateLimit, "RateLimit must be populated so the upstream handler can schedule the requeue");
             Assert.AreEqual(DateTimeOffset.FromUnixTimeSeconds(resetEpoch), ex.RateLimit!.Reset);
@@ -242,7 +274,7 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
                     new V1ConnectionReference { Id = KeepId },
                     new V1ConnectionReference { Id = AddId }
                 },
-                defaultNamespace: "default", CancellationToken.None);
+                defaultNamespace: EntityNamespace, entityName: EntityName, CancellationToken.None);
 
             var patches = handler.Requests.Where(r => r.Method == HttpMethod.Patch).ToList();
             Assert.AreEqual(2, patches.Count, "Expected one PATCH per affected connection (add + remove).");
@@ -264,30 +296,6 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
                 r.Method == HttpMethod.Patch &&
                 r.RequestUri!.AbsolutePath.EndsWith($"/connections/{KeepId}/clients")),
                 "The unchanged 'keep' connection should not be PATCHed.");
-        }
-
-        // Future-proofing — if Auth0 ever changes GET /api/v2/clients/{id}/connections from the
-        // wrapper {"connections":[...]} shape to a bare array, this test fails loudly instead of
-        // letting GetClientConnectionsAsync silently return an empty list and trigger a re-enable storm.
-        [TestMethod]
-        public async Task GetClientConnections_MalformedResponse_Rethrows()
-        {
-            var handler = new RecordingHandler((req, _) =>
-            {
-                if (req.Method == HttpMethod.Get)
-                    return new HttpResponseMessage(HttpStatusCode.OK)
-                    {
-                        // Bare-array body — NOT the wrapper shape ClientConnectionsResponse expects.
-                        Content = new StringContent("[{\"id\":\"con_x\"}]")
-                    };
-                return new HttpResponseMessage(HttpStatusCode.InternalServerError);
-            });
-            var controller = BuildController(handler);
-
-            await Assert.ThrowsExceptionAsync<Newtonsoft.Json.JsonSerializationException>(() =>
-                controller.ReconcileEnabledConnections(new FakeTenantApiAccess(), ClientId,
-                    enabledConnectionRefs: Array.Empty<V1ConnectionReference>(),
-                    defaultNamespace: "default", CancellationToken.None));
         }
 
         // Single helper for assembling the GET /clients/{id}/connections response body so the

--- a/src/Alethic.Auth0.Operator.Tests/Controllers/V1ControllerRetryAndRequeueTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Controllers/V1ControllerRetryAndRequeueTests.cs
@@ -194,6 +194,36 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
         }
 
         // ============================================================================
+        // V3: programmer-bug exceptions propagate (no silent requeue).
+        // ============================================================================
+
+        [TestMethod]
+        public async Task ReconcileAsync_Propagates_JsonSerializationException_AsProgrammerBug()
+        {
+            // A malformed Auth0 payload manifests as Newtonsoft JsonSerializationException
+            // (deep inside the SDK). Requeueing it would loop forever on the same bad input
+            // and grow the work queue without bound. The IsProgrammerBug allowlist now
+            // includes JsonSerializationException so the exception propagates and the host's
+            // crash-loop / paging machinery surfaces the break instead.
+            var entity = MakeClient();
+            var requeueCalls = new List<(V1Client entity, TimeSpan delay)>();
+
+            var kube = new Mock<IKubernetesClient>(MockBehavior.Loose);
+            var controller = new TestController(
+                kube.Object,
+                requeue: (e, d) => requeueCalls.Add((e, d)),
+                reconcileImpl: (_, __) =>
+                    throw new Newtonsoft.Json.JsonSerializationException(
+                        "simulated malformed Auth0 payload"));
+
+            await Assert.ThrowsExceptionAsync<Newtonsoft.Json.JsonSerializationException>(() =>
+                controller.ReconcileAsync(entity, CancellationToken.None));
+
+            Assert.AreEqual(0, requeueCalls.Count,
+                "Programmer-bug exceptions (JsonSerializationException) must propagate, not requeue.");
+        }
+
+        // ============================================================================
         // M2: end-to-end status-write retry-exhaustion → requeue (the original incident).
         // ============================================================================
 
@@ -321,7 +351,7 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
             protected override Task<string> Create(global::Auth0.ManagementApi.IManagementApiClient api, ClientConf conf, string defaultNamespace, CancellationToken cancellationToken)
                 => Task.FromResult(string.Empty);
 
-            protected override Task Update(global::Auth0.ManagementApi.IManagementApiClient api, string id, System.Collections.Hashtable? last, ClientConf conf, List<string> driftingFields, string defaultNamespace, Alethic.Auth0.Operator.Services.ITenantApiAccess tenantApiAccess, CancellationToken cancellationToken)
+            protected override Task Update(global::Auth0.ManagementApi.IManagementApiClient api, string id, System.Collections.Hashtable? last, ClientConf conf, IReadOnlyList<Alethic.Auth0.Operator.Controllers.DriftField> driftFields, string defaultNamespace, string entityName, Alethic.Auth0.Operator.Services.ITenantApiAccess tenantApiAccess, Alethic.Auth0.Operator.Controllers.DriftLogContext driftContext, CancellationToken cancellationToken)
                 => Task.CompletedTask;
 
             protected override Task Delete(global::Auth0.ManagementApi.IManagementApiClient api, string id, CancellationToken cancellationToken)

--- a/src/Alethic.Auth0.Operator.Tests/Controllers/V1ControllerRetryAndRequeueTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Controllers/V1ControllerRetryAndRequeueTests.cs
@@ -194,36 +194,6 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
         }
 
         // ============================================================================
-        // V3: programmer-bug exceptions propagate (no silent requeue).
-        // ============================================================================
-
-        [TestMethod]
-        public async Task ReconcileAsync_Propagates_JsonSerializationException_AsProgrammerBug()
-        {
-            // A malformed Auth0 payload manifests as Newtonsoft JsonSerializationException
-            // (deep inside the SDK). Requeueing it would loop forever on the same bad input
-            // and grow the work queue without bound. The IsProgrammerBug allowlist now
-            // includes JsonSerializationException so the exception propagates and the host's
-            // crash-loop / paging machinery surfaces the break instead.
-            var entity = MakeClient();
-            var requeueCalls = new List<(V1Client entity, TimeSpan delay)>();
-
-            var kube = new Mock<IKubernetesClient>(MockBehavior.Loose);
-            var controller = new TestController(
-                kube.Object,
-                requeue: (e, d) => requeueCalls.Add((e, d)),
-                reconcileImpl: (_, __) =>
-                    throw new Newtonsoft.Json.JsonSerializationException(
-                        "simulated malformed Auth0 payload"));
-
-            await Assert.ThrowsExceptionAsync<Newtonsoft.Json.JsonSerializationException>(() =>
-                controller.ReconcileAsync(entity, CancellationToken.None));
-
-            Assert.AreEqual(0, requeueCalls.Count,
-                "Programmer-bug exceptions (JsonSerializationException) must propagate, not requeue.");
-        }
-
-        // ============================================================================
         // M2: end-to-end status-write retry-exhaustion → requeue (the original incident).
         // ============================================================================
 

--- a/src/Alethic.Auth0.Operator/Controllers/DriftLogContext.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/DriftLogContext.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Alethic.Auth0.Operator.Controllers
+{
+    /// <summary>
+    /// Forces camelCase enum serialization for the log-payload enums in this file so the JSON shape
+    /// is uniform across <c>reconciliationType</c> and <c>driftFields[].changeType</c>. Without this
+    /// the default <see cref="JsonStringEnumConverter"/> emits PascalCase, which historically clashed
+    /// with the manual <c>.ToLowerInvariant()</c> path used for <c>reconciliationType</c> in
+    /// <see cref="V1Controller{TEntity, TSpec, TStatus, TConf}.LogAuth0ApiCall"/>.
+    /// </summary>
+    internal sealed class CamelCaseJsonStringEnumConverter : JsonStringEnumConverter
+    {
+        public CamelCaseJsonStringEnumConverter() : base(JsonNamingPolicy.CamelCase) { }
+    }
+
+    /// <summary>
+    /// Categorizes why a write to Auth0 is being issued. Allows downstream observability tooling
+    /// (Datadog dashboards in particular) to distinguish between green-field creates, drift-driven
+    /// updates, and cascading deletes — all of which currently flow through the single
+    /// <see cref="V1Controller{TEntity, TSpec, TStatus, TConf}.LogAuth0ApiCall"/> funnel.
+    /// </summary>
+    [JsonConverter(typeof(CamelCaseJsonStringEnumConverter))]
+    public enum ReconciliationType
+    {
+        /// <summary>First reconciliation - no Auth0 entity exists yet, applying full configuration.</summary>
+        First,
+
+        /// <summary>Existing Auth0 entity, configuration drift detected against desired state.</summary>
+        Drift,
+
+        /// <summary>Kubernetes CR deleted - cascading delete to Auth0.</summary>
+        Finalizer,
+    }
+
+    /// <summary>
+    /// How a single field differs between Auth0 (before) and the Kubernetes spec (after).
+    /// </summary>
+    [JsonConverter(typeof(CamelCaseJsonStringEnumConverter))]
+    public enum DriftChangeType
+    {
+        /// <summary>Field exists in desired state, missing from Auth0.</summary>
+        Added,
+
+        /// <summary>Field exists in both, values differ.</summary>
+        Modified,
+
+        /// <summary>Field exists in Auth0, missing from desired state.</summary>
+        Removed,
+    }
+
+    /// <summary>
+    /// One field-level diff between Auth0 state and the desired Kubernetes spec.
+    /// Values are pre-truncated via <see cref="LogValueFormatter.FormatValueForLogging"/> so the
+    /// serialized log entry stays under the per-line budget.
+    /// </summary>
+    public sealed record DriftField(
+        string FieldPath,
+        DriftChangeType ChangeType,
+        string? BeforeValue,
+        string? AfterValue);
+
+    /// <summary>
+    /// The why-we-wrote-to-Auth0 context attached to every <see cref="Auth0ApiCallType.Write"/>
+    /// call. Required for Write calls (enforced at runtime by <c>LogAuth0ApiCall</c>); always null
+    /// for Read calls.
+    /// </summary>
+    public sealed record DriftLogContext(
+        ReconciliationType ReconciliationType,
+        IReadOnlyList<DriftField> DriftFields,
+        string DriftReason)
+    {
+        /// <summary>
+        /// Convenience for the "first reconciliation - create branch" case. Drift fields are
+        /// undefined here (there's no prior Auth0 state to diff against).
+        /// </summary>
+        public static DriftLogContext FirstReconciliation() => new(
+            ReconciliationType.First,
+            Array.Empty<DriftField>(),
+            "first reconciliation - applying full configuration");
+
+        /// <summary>
+        /// Convenience for the "finalizer - cascading delete" case.
+        /// </summary>
+        public static DriftLogContext FinalizerDelete() => new(
+            ReconciliationType.Finalizer,
+            Array.Empty<DriftField>(),
+            "kubernetes entity deleted - cascading delete to Auth0");
+
+        /// <summary>
+        /// Convenience for the drift-update branch. Builds the human-readable summary from
+        /// the field counts so every drift log emits the same shape of summary.
+        /// </summary>
+        public static DriftLogContext Drift(IReadOnlyList<DriftField> fields)
+        {
+            var added = fields.Count(f => f.ChangeType == DriftChangeType.Added);
+            var modified = fields.Count(f => f.ChangeType == DriftChangeType.Modified);
+            var removed = fields.Count(f => f.ChangeType == DriftChangeType.Removed);
+            var reason = $"{added} added, {modified} modified, {removed} removed";
+            return new DriftLogContext(ReconciliationType.Drift, fields, reason);
+        }
+    }
+}

--- a/src/Alethic.Auth0.Operator/Controllers/DriftLogContext.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/DriftLogContext.cs
@@ -11,9 +11,9 @@ namespace Alethic.Auth0.Operator.Controllers
     /// is uniform across <c>reconciliationType</c> and <c>driftFields[].changeType</c>. Without this
     /// the default <see cref="JsonStringEnumConverter"/> emits PascalCase, which historically clashed
     /// with the manual <c>.ToLowerInvariant()</c> path used for <c>reconciliationType</c> in
-    /// <see cref="V1Controller{TEntity, TSpec, TStatus, TConf}.LogAuth0ApiCall"/>.
+    /// <see cref="V1Controller{TEntity, TSpec, TStatus, TConf}.LogAuth0Write"/>.
     /// </summary>
-    internal sealed class CamelCaseJsonStringEnumConverter : JsonStringEnumConverter
+    public sealed class CamelCaseJsonStringEnumConverter : JsonStringEnumConverter
     {
         public CamelCaseJsonStringEnumConverter() : base(JsonNamingPolicy.CamelCase) { }
     }
@@ -22,7 +22,7 @@ namespace Alethic.Auth0.Operator.Controllers
     /// Categorizes why a write to Auth0 is being issued. Allows downstream observability tooling
     /// (Datadog dashboards in particular) to distinguish between green-field creates, drift-driven
     /// updates, and cascading deletes — all of which currently flow through the single
-    /// <see cref="V1Controller{TEntity, TSpec, TStatus, TConf}.LogAuth0ApiCall"/> funnel.
+    /// <see cref="V1Controller{TEntity, TSpec, TStatus, TConf}.LogAuth0Write"/> funnel.
     /// </summary>
     [JsonConverter(typeof(CamelCaseJsonStringEnumConverter))]
     public enum ReconciliationType
@@ -57,17 +57,78 @@ namespace Alethic.Auth0.Operator.Controllers
     /// One field-level diff between Auth0 state and the desired Kubernetes spec.
     /// Values are pre-truncated via <see cref="LogValueFormatter.FormatValueForLogging"/> so the
     /// serialized log entry stays under the per-line budget.
+    /// <para>
+    /// <see cref="AfterValue"/> is intentionally <c>null</c> on the first-reconciliation
+    /// synthesis path (<see cref="V1TenantEntityController{TEntity,TConf}"/>'s
+    /// first-reconcile fields list), even though the desired value is known. The
+    /// downstream consumer there is <see cref="V1ClientController"/>'s selective-update
+    /// routing, which inspects only <see cref="FieldPath"/>. The drift-path
+    /// (<c>GetDriftFieldDetails</c>) populates both <see cref="BeforeValue"/> and
+    /// <see cref="AfterValue"/>. Don't "fix" the asymmetry without re-checking the
+    /// selective-update consumer.
+    /// </para>
     /// </summary>
-    public sealed record DriftField(
-        string FieldPath,
-        DriftChangeType ChangeType,
-        string? BeforeValue,
-        string? AfterValue);
+    public sealed record DriftField
+    {
+        /// <summary>
+        /// Secret-shaped substrings that, if observed in <see cref="BeforeValue"/> /
+        /// <see cref="AfterValue"/>, indicate the upstream redaction pass
+        /// (<see cref="LogValueFormatter.IsSensitiveKey"/>) missed a sensitive value. Failing
+        /// loud at construction is cheaper than discovering it on a Datadog log line.
+        /// </summary>
+        private static readonly string[] SecretShapedSubstrings =
+        {
+            "client_secret",
+            "bind_credentials",
+            "api_secret",
+            "signing_cert",
+            "private_key",
+        };
+
+        public string FieldPath { get; }
+
+        public DriftChangeType ChangeType { get; }
+
+        public string? BeforeValue { get; }
+
+        public string? AfterValue { get; }
+
+        public DriftField(
+            string FieldPath,
+            DriftChangeType ChangeType,
+            string? BeforeValue,
+            string? AfterValue)
+        {
+            EnsureNoSecretShape(nameof(BeforeValue), BeforeValue);
+            EnsureNoSecretShape(nameof(AfterValue), AfterValue);
+
+            this.FieldPath = FieldPath;
+            this.ChangeType = ChangeType;
+            this.BeforeValue = BeforeValue;
+            this.AfterValue = AfterValue;
+        }
+
+        private static void EnsureNoSecretShape(string paramName, string? value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return;
+
+            foreach (var marker in SecretShapedSubstrings)
+            {
+                if (value.Contains(marker, StringComparison.OrdinalIgnoreCase))
+                    throw new InvalidOperationException(
+                        $"DriftField.{paramName} contains the secret-shaped marker '{marker}'. " +
+                        $"The upstream redaction pass missed this value — fix LogValueFormatter.IsSensitiveKey " +
+                        $"(or the caller's RedactedOrFormat wrapper) rather than letting it reach the log payload.");
+            }
+        }
+    }
 
     /// <summary>
     /// The why-we-wrote-to-Auth0 context attached to every <see cref="Auth0ApiCallType.Write"/>
-    /// call. Required for Write calls (enforced at runtime by <c>LogAuth0ApiCall</c>); always null
-    /// for Read calls.
+    /// call. Required for Write calls (the non-nullable parameter on
+    /// <see cref="V1Controller{TEntity, TSpec, TStatus, TConf}.LogAuth0Write"/> enforces this at
+    /// compile time); not used by Read calls.
     /// </summary>
     public sealed record DriftLogContext(
         ReconciliationType ReconciliationType,

--- a/src/Alethic.Auth0.Operator/Controllers/LogValueFormatter.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/LogValueFormatter.cs
@@ -31,8 +31,14 @@ namespace Alethic.Auth0.Operator.Controllers
         /// value is sensitive (a secret, credential, signing key, etc.) and must never be written
         /// to the structured drift-log payload. Matching is case-insensitive substring matching —
         /// covers <c>client_secret</c>, <c>bind_credentials</c>, <c>password</c>, <c>api_secret</c>,
-        /// <c>signing_cert</c>, <c>kerberos</c>, <c>private_key</c>, <c>api_key</c>, plus any token
-        /// field. False-positives (e.g. a user-facing description that happens to contain the word
+        /// <c>signing_cert</c>, <c>signing_key</c>, <c>kerberos</c>, <c>private_key</c>,
+        /// <c>api_key</c>, <c>client_assertion</c>, <c>certificate</c>, <c>pfx</c>, plus the three
+        /// OAuth token fields (<c>access_token</c>, <c>refresh_token</c>, <c>id_token</c>) when
+        /// they appear as the trailing <c>_</c>- or <c>.</c>-bounded segment of the key. The
+        /// token rule is intentionally narrow — a plain <c>"token"</c> substring would over-match
+        /// legitimate non-secret fields like <c>token_endpoint</c>,
+        /// <c>token_endpoint_auth_method</c>, and <c>access_token_lifetime_in_seconds</c>.
+        /// False-positives (e.g. a user-facing description that happens to contain the word
         /// <c>password</c>) are acceptable; false-negatives are not.
         /// </summary>
         public static bool IsSensitiveKey(string? key)
@@ -41,16 +47,52 @@ namespace Alethic.Auth0.Operator.Controllers
                 return false;
 
             // Lowercase once; substring matching keeps the rule resilient to nested-key prefixes
-            // (e.g. "kerberos.principal", "ldap.bind_password", "saml.signing_cert").
+            // (e.g. "kerberos.principal", "ldap.bind_password", "saml.signing_cert",
+            // "oauth.access_token").
             var lower = key.ToLowerInvariant();
             return lower.Contains("secret", StringComparison.Ordinal)
                 || lower.Contains("password", StringComparison.Ordinal)
                 || lower.Contains("credential", StringComparison.Ordinal)
                 || lower.Contains("signing_cert", StringComparison.Ordinal)
+                || lower.Contains("signing_key", StringComparison.Ordinal)
                 || lower.Contains("kerberos", StringComparison.Ordinal)
                 || lower.Contains("private_key", StringComparison.Ordinal)
                 || lower.Contains("api_key", StringComparison.Ordinal)
-                || lower.Contains("token", StringComparison.Ordinal);
+                || lower.Contains("client_assertion", StringComparison.Ordinal)
+                || lower.Contains("certificate", StringComparison.Ordinal)
+                || lower.Contains("pfx", StringComparison.Ordinal)
+                || IsOAuthTokenKey(lower);
+        }
+
+        /// <summary>
+        /// Narrow OAuth-token matcher: the three secret-bearing token names
+        /// (<c>access_token</c>, <c>refresh_token</c>, <c>id_token</c>) match only when they
+        /// appear as the trailing <c>_</c>-bounded segment of the key (or are the entire key).
+        /// This keeps nested keys like <c>oauth.access_token</c> redacted while letting
+        /// non-secret config keys like <c>token_endpoint</c>, <c>token_endpoint_auth_method</c>,
+        /// and <c>access_token_lifetime_in_seconds</c> through unredacted.
+        /// </summary>
+        private static bool IsOAuthTokenKey(string lower)
+        {
+            return EndsWithSegment(lower, "access_token")
+                || EndsWithSegment(lower, "refresh_token")
+                || EndsWithSegment(lower, "id_token");
+        }
+
+        /// <summary>
+        /// Returns true when <paramref name="key"/> equals <paramref name="segment"/> or ends
+        /// with <c>{anything}{separator}{segment}</c> where separator is <c>_</c> or <c>.</c>.
+        /// </summary>
+        private static bool EndsWithSegment(string key, string segment)
+        {
+            if (key.Length < segment.Length)
+                return false;
+            if (key.Length == segment.Length)
+                return key.Equals(segment, StringComparison.Ordinal);
+            if (!key.EndsWith(segment, StringComparison.Ordinal))
+                return false;
+            var sep = key[key.Length - segment.Length - 1];
+            return sep == '_' || sep == '.';
         }
 
         public static string FormatValueForLogging(object? value)

--- a/src/Alethic.Auth0.Operator/Controllers/LogValueFormatter.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/LogValueFormatter.cs
@@ -1,0 +1,61 @@
+using System.Collections;
+using System.Linq;
+
+namespace Alethic.Auth0.Operator.Controllers
+{
+    /// <summary>
+    /// Shared value formatter for drift-log payloads. Promoted from the per-controller copies
+    /// in <c>V1TenantController</c> and <c>V1TenantEntityController</c> so every Auth0 write log
+    /// truncates identically. Caps strings at 100 chars, hashtables at 10 entries, arrays at 5
+    /// items — bounded enough that no single drift entry blows past Datadog's per-line budget.
+    /// </summary>
+    internal static class LogValueFormatter
+    {
+        public static string FormatValueForLogging(object? value)
+        {
+            if (value is null)
+                return "(null)";
+
+            // IMPORTANT: Check Hashtable before IEnumerable since Hashtable implements IEnumerable.
+            switch (value)
+            {
+                case string stringValue:
+                    var quotedStr = $"\"{stringValue}\"";
+                    return quotedStr.Length > 100 ? $"\"{stringValue[..95]}...\"" : quotedStr;
+
+                case bool boolean:
+                    return boolean.ToString().ToLowerInvariant();
+
+                case int or long or float or double or decimal:
+                    return value.ToString() ?? "(null)";
+
+                case Hashtable hashtable:
+                    var entries = hashtable.Cast<DictionaryEntry>().Take(10)
+                        .Select(entry => $"{entry.Key}: {FormatValueForLogging(entry.Value)}");
+                    var hashPreview = string.Join(", ", entries);
+                    return hashtable.Count > 10
+                        ? $"{{{hashPreview}, ...}} (total: {hashtable.Count} fields)"
+                        : $"{{{hashPreview}}}";
+
+                case IEnumerable enumerable when value is not string:
+                    // Materialize once: every IEnumerable reaching this formatter is a bounded
+                    // Auth0 SDK DTO collection (tens of entries, never thousands), so .ToList() is
+                    // safe and necessary — the previous double-enumeration pattern (Take + Count)
+                    // would re-execute lazy / one-shot enumerables or throw on the second pass.
+                    var materialized = enumerable.Cast<object>().ToList();
+                    var items = materialized.Take(5).Select(FormatValueForLogging);
+                    var arrayPreview = string.Join(", ", items);
+                    return materialized.Count > 5
+                        ? $"[{arrayPreview}, ...] (total: {materialized.Count} items)"
+                        : $"[{arrayPreview}]";
+
+                default:
+                    var objectStr = value.ToString() ?? "(null)";
+                    var typeName = value.GetType().Name;
+                    return objectStr.Length > 80
+                        ? $"({typeName}) {objectStr[..75]}..."
+                        : $"({typeName}) {objectStr}";
+            }
+        }
+    }
+}

--- a/src/Alethic.Auth0.Operator/Controllers/LogValueFormatter.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/LogValueFormatter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Linq;
 
@@ -8,9 +9,50 @@ namespace Alethic.Auth0.Operator.Controllers
     /// in <c>V1TenantController</c> and <c>V1TenantEntityController</c> so every Auth0 write log
     /// truncates identically. Caps strings at 100 chars, hashtables at 10 entries, arrays at 5
     /// items — bounded enough that no single drift entry blows past Datadog's per-line budget.
+    /// <para>
+    /// Sensitive-key redaction: when walking a <see cref="Hashtable"/>, any entry whose key
+    /// matches <see cref="IsSensitiveKey"/> (database/AD/LDAP/SAML/OAuth secrets, signing keys,
+    /// kerberos blobs, etc.) is replaced with <c>(redacted)</c> before its value is serialized.
+    /// This keeps the structured drift-log JSON from shipping Auth0 secrets to Datadog when a
+    /// connection's <c>options</c> hashtable drifts.
+    /// </para>
     /// </summary>
     internal static class LogValueFormatter
     {
+        /// <summary>
+        /// Placeholder written into the drift-log payload in place of a sensitive value.
+        /// Kept identical to what the <see cref="DriftField"/> constructor guard expects so a
+        /// regression that skips redaction trips the guard instead of leaking the secret.
+        /// </summary>
+        internal const string RedactedPlaceholder = "(redacted)";
+
+        /// <summary>
+        /// Returns true if <paramref name="key"/> names an Auth0 / connection-options field whose
+        /// value is sensitive (a secret, credential, signing key, etc.) and must never be written
+        /// to the structured drift-log payload. Matching is case-insensitive substring matching —
+        /// covers <c>client_secret</c>, <c>bind_credentials</c>, <c>password</c>, <c>api_secret</c>,
+        /// <c>signing_cert</c>, <c>kerberos</c>, <c>private_key</c>, <c>api_key</c>, plus any token
+        /// field. False-positives (e.g. a user-facing description that happens to contain the word
+        /// <c>password</c>) are acceptable; false-negatives are not.
+        /// </summary>
+        public static bool IsSensitiveKey(string? key)
+        {
+            if (string.IsNullOrEmpty(key))
+                return false;
+
+            // Lowercase once; substring matching keeps the rule resilient to nested-key prefixes
+            // (e.g. "kerberos.principal", "ldap.bind_password", "saml.signing_cert").
+            var lower = key.ToLowerInvariant();
+            return lower.Contains("secret", StringComparison.Ordinal)
+                || lower.Contains("password", StringComparison.Ordinal)
+                || lower.Contains("credential", StringComparison.Ordinal)
+                || lower.Contains("signing_cert", StringComparison.Ordinal)
+                || lower.Contains("kerberos", StringComparison.Ordinal)
+                || lower.Contains("private_key", StringComparison.Ordinal)
+                || lower.Contains("api_key", StringComparison.Ordinal)
+                || lower.Contains("token", StringComparison.Ordinal);
+        }
+
         public static string FormatValueForLogging(object? value)
         {
             if (value is null)
@@ -31,7 +73,9 @@ namespace Alethic.Auth0.Operator.Controllers
 
                 case Hashtable hashtable:
                     var entries = hashtable.Cast<DictionaryEntry>().Take(10)
-                        .Select(entry => $"{entry.Key}: {FormatValueForLogging(entry.Value)}");
+                        .Select(entry => IsSensitiveKey(entry.Key?.ToString())
+                            ? $"{entry.Key}: {RedactedPlaceholder}"
+                            : $"{entry.Key}: {FormatValueForLogging(entry.Value)}");
                     var hashPreview = string.Join(", ", entries);
                     return hashtable.Count > 10
                         ? $"{{{hashPreview}, ...}} (total: {hashtable.Count} fields)"

--- a/src/Alethic.Auth0.Operator/Controllers/V1ClientController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1ClientController.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -62,7 +61,7 @@ namespace Alethic.Auth0.Operator.Controllers
             try
             {
                 LogAuth0ApiCall($"Getting Auth0 client with ID: {id}", Auth0ApiCallType.Read, "A0Client", id,
-                    defaultNamespace, "retrieve_client_by_id");
+                    defaultNamespace, "retrieve_client_by_id", driftContext: null);
                 return TransformToSystemTextJson<Hashtable>(await api.Clients.GetAsync(id,
                     cancellationToken: cancellationToken));
             }
@@ -151,7 +150,7 @@ namespace Alethic.Auth0.Operator.Controllers
             try
             {
                 LogAuth0ApiCall($"Getting Auth0 client by client ID: {clientId}", Auth0ApiCallType.Read, "A0Client",
-                    entity.Name(), entity.Namespace(), "retrieve_client_by_clientid");
+                    entity.Name(), entity.Namespace(), "retrieve_client_by_clientid", driftContext: null);
                 var client = await api.Clients.GetAsync(clientId, "client_id,name",
                     cancellationToken: cancellationToken);
                 Logger.LogInformationJson(
@@ -256,7 +255,7 @@ namespace Alethic.Auth0.Operator.Controllers
                 });
 
             LogAuth0ApiCall($"Getting all Auth0 clients for name-based lookup", Auth0ApiCallType.Read, "A0Client",
-                entity.Name(), entity.Namespace(), "retrieve_all_clients_for_name_lookup");
+                entity.Name(), entity.Namespace(), "retrieve_all_clients_for_name_lookup", driftContext: null);
             var list = await GetAllClientsWithPagination(api, entity, cancellationToken);
             Logger.LogDebugJson(
                 $"{EntityTypeName} {entity.Namespace()}/{entity.Name()} searched {list.Count} clients for name-based lookup",
@@ -369,7 +368,7 @@ namespace Alethic.Auth0.Operator.Controllers
                 });
 
             LogAuth0ApiCall($"Getting all Auth0 clients for callback URL lookup", Auth0ApiCallType.Read, "A0Client",
-                entity.Name(), entity.Namespace(), "retrieve_all_clients_for_callback_lookup");
+                entity.Name(), entity.Namespace(), "retrieve_all_clients_for_callback_lookup", driftContext: null);
             var clients = await GetAllClientsWithPagination(api, entity, cancellationToken);
 
             var matchingClients = clients
@@ -518,7 +517,7 @@ namespace Alethic.Auth0.Operator.Controllers
             try
             {
                 LogAuth0ApiCall($"Creating Auth0 client with name: {conf.Name}", Auth0ApiCallType.Write, "A0Client",
-                    conf.Name ?? "unknown", "unknown", "create_client");
+                    conf.Name ?? "unknown", "unknown", "create_client", DriftLogContext.FirstReconciliation());
                 var self = await api.Clients.CreateAsync(createRequest, cancellationToken);
                 var duration = DateTimeOffset.UtcNow - startTime;
                 Logger.LogInformationJson(
@@ -547,22 +546,23 @@ namespace Alethic.Auth0.Operator.Controllers
 
         /// <inheritdoc />
         protected override async Task Update(IManagementApiClient api, string id, Hashtable? last, ClientConf conf,
-            List<string> driftingFields, string defaultNamespace, ITenantApiAccess tenantApiAccess, CancellationToken cancellationToken)
+            IReadOnlyList<DriftField> driftFields, string defaultNamespace, string entityName, ITenantApiAccess tenantApiAccess, DriftLogContext driftContext, CancellationToken cancellationToken)
         {
             var startTime = DateTimeOffset.UtcNow;
+            var driftingFieldNames = driftFields.Select(d => d.FieldPath).ToArray();
             Logger.LogInformationJson($"{EntityTypeName} updating client in Auth0 with id: {id} and name: {conf.Name}",
                 new
                 {
                     entityTypeName = EntityTypeName,
                     clientId = id,
                     clientName = conf.Name,
-                    driftingFields = driftingFields.ToArray()
+                    driftingFields = driftingFieldNames
                 });
 
             // Determine what needs to be updated based on drifting fields
-            var needsClientUpdate = driftingFields.Any(field =>
+            var needsClientUpdate = driftingFieldNames.Any(field =>
                 !string.Equals(field, "enabled_connections", StringComparison.OrdinalIgnoreCase));
-            var needsConnectionUpdate = driftingFields.Any(field =>
+            var needsConnectionUpdate = driftingFieldNames.Any(field =>
                 string.Equals(field, "enabled_connections", StringComparison.OrdinalIgnoreCase));
 
             Logger.LogInformationJson($"{EntityTypeName} selective update analysis for client {id}: needsClientUpdate={needsClientUpdate}, needsConnectionUpdate={needsConnectionUpdate}",
@@ -572,13 +572,13 @@ namespace Alethic.Auth0.Operator.Controllers
                     clientId = id,
                     needsClientUpdate,
                     needsConnectionUpdate,
-                    driftingFields = driftingFields.ToArray()
+                    driftingFields = driftingFieldNames
                 });
 
             // Update client properties if any non-enabled_connections fields have drifted
             if (needsClientUpdate)
             {
-                await UpdateClientProperties(api, id, last, conf, cancellationToken);
+                await UpdateClientProperties(api, id, last, conf, driftContext, cancellationToken);
             }
             else
             {
@@ -595,7 +595,7 @@ namespace Alethic.Auth0.Operator.Controllers
             if (needsConnectionUpdate)
             {
                 await ReconcileEnabledConnections(tenantApiAccess, id, conf.EnabledConnections, defaultNamespace,
-                    cancellationToken);
+                    entityName, cancellationToken);
             }
             else
             {
@@ -630,7 +630,7 @@ namespace Alethic.Auth0.Operator.Controllers
         /// <param name="last">Last known configuration from Auth0</param>
         /// <param name="conf">Desired client configuration</param>
         /// <param name="cancellationToken">Cancellation token</param>
-        private async Task UpdateClientProperties(IManagementApiClient api, string id, Hashtable? last, ClientConf conf, CancellationToken cancellationToken)
+        private async Task UpdateClientProperties(IManagementApiClient api, string id, Hashtable? last, ClientConf conf, DriftLogContext driftContext, CancellationToken cancellationToken)
         {
             Logger.LogInformationJson($"{EntityTypeName} updating client properties for {id}",
                 new
@@ -671,7 +671,7 @@ namespace Alethic.Auth0.Operator.Controllers
             try
             {
                 LogAuth0ApiCall($"Updating Auth0 client properties with ID: {id}", Auth0ApiCallType.Write,
-                    "A0Client", conf.Name ?? "unknown", "unknown", "update_client_properties");
+                    "A0Client", conf.Name ?? "unknown", "unknown", "update_client_properties", driftContext);
                 await api.Clients.UpdateAsync(id, req, cancellationToken);
 
                 Logger.LogInformationJson(
@@ -975,7 +975,7 @@ namespace Alethic.Auth0.Operator.Controllers
             try
             {
                 LogAuth0ApiCall($"Deleting Auth0 client with ID: {id}", Auth0ApiCallType.Write, "A0Client", id,
-                    "unknown", "delete_client");
+                    "unknown", "delete_client", DriftLogContext.FinalizerDelete());
                 await api.Clients.DeleteAsync(id, cancellationToken);
                 Logger.LogInformationJson($"{EntityTypeName} successfully deleted client from Auth0 with ID: {id}", new
                 {
@@ -1185,7 +1185,7 @@ namespace Alethic.Auth0.Operator.Controllers
             string clientId, string defaultNamespace, CancellationToken cancellationToken)
         {
             LogAuth0ApiCall($"Getting enabled connections for client: {clientId}", Auth0ApiCallType.Read,
-                "A0Connection", clientId, defaultNamespace, "get_client_connections_direct");
+                "A0Connection", clientId, defaultNamespace, "get_client_connections_direct", driftContext: null);
 
             // Use the direct Auth0 Management API endpoint: GET /api/v2/clients/{id}/connections
             var requestUri = new Uri(tenantApiAccess.BaseUri, $"clients/{clientId}/connections");
@@ -1198,33 +1198,35 @@ namespace Alethic.Auth0.Operator.Controllers
             if (!response.IsSuccessStatusCode)
             {
                 var failureBody = await ReadBodySafelyAsync(response, cancellationToken);
-                ThrowFromHttpFailure(response, failureBody, "get_client_connections",
-                    connectionId: "-", clientId);
+                await ThrowFromHttpFailureAsync(response, failureBody, "get_client_connections",
+                    connectionId: "-", clientId, cancellationToken);
             }
 
-            var jsonContent = await response.Content.ReadAsStringAsync(cancellationToken);
-            var responseData =
-                Newtonsoft.Json.JsonConvert.DeserializeObject<ClientConnectionsResponse>(jsonContent);
-            var connections = responseData?.Connections;
+            {
+                var jsonContent = await response.Content.ReadAsStringAsync(cancellationToken);
+                var responseData =
+                    Newtonsoft.Json.JsonConvert.DeserializeObject<ClientConnectionsResponse>(jsonContent);
+                var connections = responseData?.Connections;
 
-            Logger.LogInformationJson(
-                $"{EntityTypeName} retrieved {connections?.Count ?? 0} connections directly for client {clientId}",
-                new
-                {
-                    entityTypeName = EntityTypeName,
-                    clientId,
-                    connectionCount = connections?.Count ?? 0,
-                    operation = "get_client_connections_direct",
-                    baseUri = tenantApiAccess.BaseUri.ToString()
-                });
+                Logger.LogInformationJson(
+                    $"{EntityTypeName} retrieved {connections?.Count ?? 0} connections directly for client {clientId}",
+                    new
+                    {
+                        entityTypeName = EntityTypeName,
+                        clientId,
+                        connectionCount = connections?.Count ?? 0,
+                        operation = "get_client_connections_direct",
+                        baseUri = tenantApiAccess.BaseUri.ToString()
+                    });
 
-            return connections ?? new List<Connection>();
+                return connections ?? new List<Connection>();
+            }
         }
 
 
         internal async Task ReconcileEnabledConnections(ITenantApiAccess tenantApiAccess, string clientId,
             V1ConnectionReference[]? enabledConnectionRefs, string defaultNamespace,
-            CancellationToken cancellationToken)
+            string entityName, CancellationToken cancellationToken)
         {
             try
             {
@@ -1235,7 +1237,7 @@ namespace Alethic.Auth0.Operator.Controllers
                     CalculateConnectionDifferences(currentConnectionIds, desiredConnectionIds);
 
                 await ApplyConnectionChanges(tenantApiAccess, clientId, connectionsToAdd, connectionsToRemove,
-                    defaultNamespace, cancellationToken);
+                    defaultNamespace, entityName, cancellationToken);
                 LogReconciliationResult(clientId, currentConnectionIds.Count, connectionsToAdd.Count,
                     connectionsToRemove.Count);
             }
@@ -1298,15 +1300,16 @@ namespace Alethic.Auth0.Operator.Controllers
 
         private async Task ApplyConnectionChanges(ITenantApiAccess tenantApiAccess, string clientId,
             List<string> connectionsToAdd, List<string> connectionsToRemove,
-            string defaultNamespace, CancellationToken cancellationToken)
+            string entityNamespace, string entityName,
+            CancellationToken cancellationToken)
         {
             foreach (var connectionId in connectionsToAdd)
-                await EnableClientOnConnectionAsync(tenantApiAccess, connectionId, clientId, defaultNamespace,
-                    cancellationToken);
+                await EnableClientOnConnectionAsync(tenantApiAccess, connectionId, clientId,
+                    entityNamespace, entityName, cancellationToken);
 
             foreach (var connectionId in connectionsToRemove)
-                await DisableClientOnConnectionAsync(tenantApiAccess, connectionId, clientId, defaultNamespace,
-                    cancellationToken);
+                await DisableClientOnConnectionAsync(tenantApiAccess, connectionId, clientId,
+                    entityNamespace, entityName, cancellationToken);
         }
 
         private void LogReconciliationResult(string clientId, int currentConnectionCount, int addedCount,
@@ -1340,36 +1343,87 @@ namespace Alethic.Auth0.Operator.Controllers
         }
 
         /// <summary>PATCH /api/v2/connections/{connectionId}/clients with <c>[{client_id, status:true}]</c> — enables a single client on a connection.</summary>
+        /// <remarks>
+        /// CR-4 contract: callers must verify <see cref="V1EntityPolicyType.Update"/> is in
+        /// <c>entity.Spec.Policy</c> before invoking. The canonical gate lives at
+        /// <see cref="V1TenantEntityController{TEntity,TConf}.ApplyUpdatesIfNeeded"/>. Bypassing
+        /// this is a programmer bug.
+        /// </remarks>
         internal Task EnableClientOnConnectionAsync(ITenantApiAccess tenantApiAccess, string connectionId,
-            string clientId, string defaultNamespace, CancellationToken cancellationToken)
+            string clientId, string entityNamespace, string entityName,
+            CancellationToken cancellationToken)
         {
+            var driftContext = BuildMembershipDriftContext(
+                clientId, connectionId,
+                changeType: DriftChangeType.Added,
+                reasonVerb: "enable");
+
             return PatchConnectionClientsAsync(tenantApiAccess, connectionId, clientId,
                 status: true,
                 operation: "enable_client_on_connection",
-                defaultNamespace,
+                entityNamespace: entityNamespace,
+                entityName: entityName,
+                driftContext: driftContext,
                 cancellationToken);
         }
 
         /// <summary>PATCH /api/v2/connections/{connectionId}/clients with <c>[{client_id, status:false}]</c> — disables a single client on a connection.</summary>
+        /// <remarks>
+        /// CR-4 contract: callers must verify <see cref="V1EntityPolicyType.Update"/> is in
+        /// <c>entity.Spec.Policy</c> before invoking. The canonical gate lives at
+        /// <see cref="V1TenantEntityController{TEntity,TConf}.ApplyUpdatesIfNeeded"/>. Bypassing
+        /// this is a programmer bug.
+        /// </remarks>
         internal Task DisableClientOnConnectionAsync(ITenantApiAccess tenantApiAccess, string connectionId,
-            string clientId, string defaultNamespace, CancellationToken cancellationToken)
+            string clientId, string entityNamespace, string entityName,
+            CancellationToken cancellationToken)
         {
+            var driftContext = BuildMembershipDriftContext(
+                clientId, connectionId,
+                changeType: DriftChangeType.Removed,
+                reasonVerb: "disable");
+
             return PatchConnectionClientsAsync(tenantApiAccess, connectionId, clientId,
                 status: false,
                 operation: "disable_client_on_connection",
-                defaultNamespace,
+                entityNamespace: entityNamespace,
+                entityName: entityName,
+                driftContext: driftContext,
                 cancellationToken);
+        }
+
+        /// <summary>
+        /// Builds the synthetic <see cref="DriftLogContext"/> describing a single
+        /// client/connection membership transition. The "drift" here is itself the membership
+        /// change — modeled as one <see cref="DriftField"/> on
+        /// <c>spec.conf.enabled_connections[connectionId]</c>.
+        /// </summary>
+        private static DriftLogContext BuildMembershipDriftContext(string clientId, string connectionId,
+            DriftChangeType changeType, string reasonVerb)
+        {
+            var field = new DriftField(
+                FieldPath: $"spec.conf.enabled_connections[{connectionId}]",
+                ChangeType: changeType,
+                BeforeValue: changeType == DriftChangeType.Added ? null : connectionId,
+                AfterValue: changeType == DriftChangeType.Added ? connectionId : null);
+
+            return new DriftLogContext(
+                ReconciliationType.Drift,
+                new[] { field },
+                $"client {clientId} connection-membership change: {reasonVerb} {connectionId}");
         }
 
         /// <summary>
         /// Issues a single <c>PATCH /api/v2/connections/{connectionId}/clients</c> with a one-row
         /// body <c>[{client_id, status}]</c> — Auth0's replacement for the deprecated
         /// <c>enabled_clients</c> field. Success is HTTP 204 (No Content); any other status surfaces
-        /// via <see cref="ThrowFromHttpFailure"/>. No benign-4xx handling is required because
+        /// via <see cref="ThrowFromHttpFailureAsync"/>. No benign-4xx handling is required because
         /// the endpoint is idempotent and returns 204 regardless of prior membership state.
         /// </summary>
         private async Task PatchConnectionClientsAsync(ITenantApiAccess tenantApiAccess, string connectionId,
-            string clientId, bool status, string operation, string defaultNamespace,
+            string clientId, bool status, string operation,
+            string entityNamespace, string entityName,
+            DriftLogContext driftContext,
             CancellationToken cancellationToken)
         {
             var requestUri = new Uri(tenantApiAccess.BaseUri, $"connections/{connectionId}/clients");
@@ -1378,8 +1432,19 @@ namespace Alethic.Auth0.Operator.Controllers
                 new { client_id = clientId, status }
             });
 
-            LogAuth0ApiCall($"{operation} for client {clientId} on connection {connectionId}",
-                Auth0ApiCallType.Write, "A0Client", clientId, defaultNamespace, operation);
+            // Funnel every membership-change write through LogAuth0ApiCall so it shows up in the
+            // Datadog "Auth0 writes" tally (@auth0ApiCallType:write) alongside every other write,
+            // and carries the same DriftLogContext payload shape. The post-success info-log below
+            // stays purely as a success/no-op outcome marker — the drift context lives on the
+            // pre-write log to keep a single source of truth.
+            LogAuth0ApiCall(
+                message: $"{operation} for client {clientId} on connection {connectionId}",
+                apiCallType: Auth0ApiCallType.Write,
+                entityType: EntityTypeName,
+                entityName: entityName,
+                entityNamespace: entityNamespace,
+                purpose: operation,
+                driftContext: driftContext);
 
             using var response = await SendWithTokenAndRetryAsync(tenantApiAccess,
                 () => new HttpRequestMessage(HttpMethod.Patch, requestUri)
@@ -1391,13 +1456,41 @@ namespace Alethic.Auth0.Operator.Controllers
             if (response.IsSuccessStatusCode)
             {
                 Logger.LogInformationJson(
-                    $"{EntityTypeName} {operation} succeeded for client {clientId} on connection {connectionId}",
-                    new { entityTypeName = EntityTypeName, connectionId, clientId, operation, status = "success" });
+                    $"{EntityTypeName} {entityNamespace}/{entityName} {operation} succeeded for client {clientId} on connection {connectionId}",
+                    new
+                    {
+                        entityTypeName = EntityTypeName,
+                        entityNamespace,
+                        entityName,
+                        connectionId,
+                        clientId,
+                        operation,
+                        status = "success",
+                    });
                 return;
             }
 
             var body = await ReadBodySafelyAsync(response, cancellationToken);
-            ThrowFromHttpFailure(response, body, operation, connectionId, clientId);
+
+            // H3: symmetric failure log. Mirrors the pre-write LogAuth0ApiCall above so the
+            // Datadog "Auth0 writes" widget keyed on @auth0ApiCallType:write has both a
+            // before-call (Warning) and an after-failure (Error) line for every failed PATCH.
+            Logger.LogErrorJson(
+                $"{EntityTypeName} {entityNamespace}/{entityName} {operation} for client {clientId} on connection {connectionId} FAILED with HTTP {(int)response.StatusCode}",
+                new
+                {
+                    entityTypeName = EntityTypeName,
+                    entityNamespace,
+                    entityName,
+                    connectionId,
+                    clientId,
+                    operation,
+                    status = "failed",
+                    httpStatusCode = (int)response.StatusCode,
+                    reconciliationType = driftContext.ReconciliationType,
+                    driftReason = driftContext.DriftReason,
+                });
+            await ThrowFromHttpFailureAsync(response, body, operation, connectionId, clientId, cancellationToken);
         }
 
         /// <summary>
@@ -1451,33 +1544,45 @@ namespace Alethic.Auth0.Operator.Controllers
         /// <summary>
         /// Throws an exception that preserves the status code and Auth0 body for the upstream retry+backoff wrapper.
         /// 429 maps to <see cref="RateLimitApiException"/> so the existing rate-limit handler reschedules per <c>X-RateLimit-Reset</c>.
+        /// All other non-success statuses map to <see cref="ErrorApiException"/> (mirroring
+        /// <c>Auth0.Core.Exceptions.ApiException.CreateSpecificExceptionAsync</c>) so the tier-1
+        /// catch in <see cref="V1Controller{TEntity,TConf}"/> reads <c>StatusCode</c>+<c>ApiError</c>
+        /// directly and labels the Event accordingly instead of falling into the generic
+        /// "Unknown error" branch (CR-1).
         /// Callers own the response lifetime (via <c>using</c>); this method does not dispose it.
         /// </summary>
-        [DoesNotReturn]
-        private static void ThrowFromHttpFailure(HttpResponseMessage response, string body, string operation,
-            string connectionId, string clientId)
+        private Task ThrowFromHttpFailureAsync(HttpResponseMessage response, string body, string operation,
+            string connectionId, string clientId, CancellationToken cancellationToken)
         {
             var statusCode = (int)response.StatusCode;
+            var apiError = ParseApiErrorOrEmpty(body);
 
             if (statusCode == 429)
             {
                 var rateLimit = RateLimit.Parse(response.Headers);
-                ApiError apiError;
-                try
-                {
-                    apiError = (string.IsNullOrWhiteSpace(body)
-                        ? null
-                        : JsonConvert.DeserializeObject<ApiError>(body)) ?? new ApiError();
-                }
-                catch
-                {
-                    apiError = new ApiError();
-                }
                 throw new RateLimitApiException(rateLimit, apiError);
             }
 
-            throw new HttpRequestException(
-                $"Auth0 {operation} for client {clientId} on connection {connectionId} returned HTTP {statusCode}: {body}");
+            throw new ErrorApiException(response.StatusCode, apiError);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON Auth0 error body into an <see cref="ApiError"/>, swallowing
+        /// malformed bodies so we still propagate a typed exception with the correct
+        /// <see cref="HttpStatusCode"/> upstream.
+        /// </summary>
+        private static ApiError ParseApiErrorOrEmpty(string body)
+        {
+            if (string.IsNullOrWhiteSpace(body))
+                return new ApiError();
+            try
+            {
+                return JsonConvert.DeserializeObject<ApiError>(body) ?? new ApiError();
+            }
+            catch
+            {
+                return new ApiError();
+            }
         }
 
         /// <summary>

--- a/src/Alethic.Auth0.Operator/Controllers/V1ClientController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1ClientController.cs
@@ -60,8 +60,8 @@ namespace Alethic.Auth0.Operator.Controllers
         {
             try
             {
-                LogAuth0ApiCall($"Getting Auth0 client with ID: {id}", Auth0ApiCallType.Read, "A0Client", id,
-                    defaultNamespace, "retrieve_client_by_id", driftContext: null);
+                LogAuth0Read($"Getting Auth0 client with ID: {id}", "A0Client", id,
+                    defaultNamespace, "retrieve_client_by_id");
                 return TransformToSystemTextJson<Hashtable>(await api.Clients.GetAsync(id,
                     cancellationToken: cancellationToken));
             }
@@ -149,8 +149,8 @@ namespace Alethic.Auth0.Operator.Controllers
 
             try
             {
-                LogAuth0ApiCall($"Getting Auth0 client by client ID: {clientId}", Auth0ApiCallType.Read, "A0Client",
-                    entity.Name(), entity.Namespace(), "retrieve_client_by_clientid", driftContext: null);
+                LogAuth0Read($"Getting Auth0 client by client ID: {clientId}", "A0Client",
+                    entity.Name(), entity.Namespace(), "retrieve_client_by_clientid");
                 var client = await api.Clients.GetAsync(clientId, "client_id,name",
                     cancellationToken: cancellationToken);
                 Logger.LogInformationJson(
@@ -254,8 +254,8 @@ namespace Alethic.Auth0.Operator.Controllers
                     clientName = conf.Name
                 });
 
-            LogAuth0ApiCall($"Getting all Auth0 clients for name-based lookup", Auth0ApiCallType.Read, "A0Client",
-                entity.Name(), entity.Namespace(), "retrieve_all_clients_for_name_lookup", driftContext: null);
+            LogAuth0Read($"Getting all Auth0 clients for name-based lookup", "A0Client",
+                entity.Name(), entity.Namespace(), "retrieve_all_clients_for_name_lookup");
             var list = await GetAllClientsWithPagination(api, entity, cancellationToken);
             Logger.LogDebugJson(
                 $"{EntityTypeName} {entity.Namespace()}/{entity.Name()} searched {list.Count} clients for name-based lookup",
@@ -367,8 +367,8 @@ namespace Alethic.Auth0.Operator.Controllers
                     searchMode = modeName
                 });
 
-            LogAuth0ApiCall($"Getting all Auth0 clients for callback URL lookup", Auth0ApiCallType.Read, "A0Client",
-                entity.Name(), entity.Namespace(), "retrieve_all_clients_for_callback_lookup", driftContext: null);
+            LogAuth0Read($"Getting all Auth0 clients for callback URL lookup", "A0Client",
+                entity.Name(), entity.Namespace(), "retrieve_all_clients_for_callback_lookup");
             var clients = await GetAllClientsWithPagination(api, entity, cancellationToken);
 
             var matchingClients = clients
@@ -516,7 +516,7 @@ namespace Alethic.Auth0.Operator.Controllers
 
             try
             {
-                LogAuth0ApiCall($"Creating Auth0 client with name: {conf.Name}", Auth0ApiCallType.Write, "A0Client",
+                LogAuth0Write($"Creating Auth0 client with name: {conf.Name}", "A0Client",
                     conf.Name ?? "unknown", "unknown", "create_client", DriftLogContext.FirstReconciliation());
                 var self = await api.Clients.CreateAsync(createRequest, cancellationToken);
                 var duration = DateTimeOffset.UtcNow - startTime;
@@ -670,7 +670,7 @@ namespace Alethic.Auth0.Operator.Controllers
 
             try
             {
-                LogAuth0ApiCall($"Updating Auth0 client properties with ID: {id}", Auth0ApiCallType.Write,
+                LogAuth0Write($"Updating Auth0 client properties with ID: {id}",
                     "A0Client", conf.Name ?? "unknown", "unknown", "update_client_properties", driftContext);
                 await api.Clients.UpdateAsync(id, req, cancellationToken);
 
@@ -974,7 +974,7 @@ namespace Alethic.Auth0.Operator.Controllers
                 });
             try
             {
-                LogAuth0ApiCall($"Deleting Auth0 client with ID: {id}", Auth0ApiCallType.Write, "A0Client", id,
+                LogAuth0Write($"Deleting Auth0 client with ID: {id}", "A0Client", id,
                     "unknown", "delete_client", DriftLogContext.FinalizerDelete());
                 await api.Clients.DeleteAsync(id, cancellationToken);
                 Logger.LogInformationJson($"{EntityTypeName} successfully deleted client from Auth0 with ID: {id}", new
@@ -1184,8 +1184,8 @@ namespace Alethic.Auth0.Operator.Controllers
         private async Task<List<Connection>> GetClientConnectionsAsync(ITenantApiAccess tenantApiAccess,
             string clientId, string defaultNamespace, CancellationToken cancellationToken)
         {
-            LogAuth0ApiCall($"Getting enabled connections for client: {clientId}", Auth0ApiCallType.Read,
-                "A0Connection", clientId, defaultNamespace, "get_client_connections_direct", driftContext: null);
+            LogAuth0Read($"Getting enabled connections for client: {clientId}",
+                "A0Connection", clientId, defaultNamespace, "get_client_connections_direct");
 
             // Use the direct Auth0 Management API endpoint: GET /api/v2/clients/{id}/connections
             var requestUri = new Uri(tenantApiAccess.BaseUri, $"clients/{clientId}/connections");
@@ -1396,13 +1396,17 @@ namespace Alethic.Auth0.Operator.Controllers
         /// Builds the synthetic <see cref="DriftLogContext"/> describing a single
         /// client/connection membership transition. The "drift" here is itself the membership
         /// change — modeled as one <see cref="DriftField"/> on
-        /// <c>spec.conf.enabled_connections[connectionId]</c>.
+        /// <c>spec.conf.enabled_connections</c>. The connection ID lives in
+        /// <see cref="DriftField.BeforeValue"/> / <see cref="DriftField.AfterValue"/>, not in
+        /// the field path — otherwise Datadog log-search facets keyed on
+        /// <c>@driftFields[*].fieldPath</c> would have unbounded cardinality (one bucket per
+        /// connection ID ever processed) instead of a stable handful of conceptual operations.
         /// </summary>
         private static DriftLogContext BuildMembershipDriftContext(string clientId, string connectionId,
             DriftChangeType changeType, string reasonVerb)
         {
             var field = new DriftField(
-                FieldPath: $"spec.conf.enabled_connections[{connectionId}]",
+                FieldPath: "spec.conf.enabled_connections",
                 ChangeType: changeType,
                 BeforeValue: changeType == DriftChangeType.Added ? null : connectionId,
                 AfterValue: changeType == DriftChangeType.Added ? connectionId : null);
@@ -1432,14 +1436,13 @@ namespace Alethic.Auth0.Operator.Controllers
                 new { client_id = clientId, status }
             });
 
-            // Funnel every membership-change write through LogAuth0ApiCall so it shows up in the
+            // Funnel every membership-change write through LogAuth0Write so it shows up in the
             // Datadog "Auth0 writes" tally (@auth0ApiCallType:write) alongside every other write,
             // and carries the same DriftLogContext payload shape. The post-success info-log below
             // stays purely as a success/no-op outcome marker — the drift context lives on the
             // pre-write log to keep a single source of truth.
-            LogAuth0ApiCall(
+            LogAuth0Write(
                 message: $"{operation} for client {clientId} on connection {connectionId}",
-                apiCallType: Auth0ApiCallType.Write,
                 entityType: EntityTypeName,
                 entityName: entityName,
                 entityNamespace: entityNamespace,
@@ -1472,9 +1475,16 @@ namespace Alethic.Auth0.Operator.Controllers
 
             var body = await ReadBodySafelyAsync(response, cancellationToken);
 
-            // H3: symmetric failure log. Mirrors the pre-write LogAuth0ApiCall above so the
+            // H3: symmetric failure log. Mirrors the pre-write LogAuth0Write above so the
             // Datadog "Auth0 writes" widget keyed on @auth0ApiCallType:write has both a
             // before-call (Warning) and an after-failure (Error) line for every failed PATCH.
+            //
+            // reconciliationType is serialized via ToString().ToLowerInvariant() — not as the raw
+            // enum — so it matches what _structuredLogJsonOptions emits in LogAuth0Write (where the
+            // boxed-enum path runs through the camelCase [JsonConverter] attribute). Without this,
+            // LogErrorJson's serializer would emit "reconciliationType":1 here while the success
+            // path emits "reconciliationType":"drift", silently breaking any Datadog dashboard keyed
+            // on the string value.
             Logger.LogErrorJson(
                 $"{EntityTypeName} {entityNamespace}/{entityName} {operation} for client {clientId} on connection {connectionId} FAILED with HTTP {(int)response.StatusCode}",
                 new
@@ -1487,7 +1497,7 @@ namespace Alethic.Auth0.Operator.Controllers
                     operation,
                     status = "failed",
                     httpStatusCode = (int)response.StatusCode,
-                    reconciliationType = driftContext.ReconciliationType,
+                    reconciliationType = driftContext.ReconciliationType.ToString().ToLowerInvariant(),
                     driftReason = driftContext.DriftReason,
                 });
             await ThrowFromHttpFailureAsync(response, body, operation, connectionId, clientId, cancellationToken);

--- a/src/Alethic.Auth0.Operator/Controllers/V1ClientController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1ClientController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -1198,8 +1199,8 @@ namespace Alethic.Auth0.Operator.Controllers
             if (!response.IsSuccessStatusCode)
             {
                 var failureBody = await ReadBodySafelyAsync(response, cancellationToken);
-                await ThrowFromHttpFailureAsync(response, failureBody, "get_client_connections",
-                    connectionId: "-", clientId, cancellationToken);
+                ThrowFromHttpFailure(response, failureBody, "get_client_connections",
+                    connectionId: "-", clientId);
             }
 
             {
@@ -1421,7 +1422,7 @@ namespace Alethic.Auth0.Operator.Controllers
         /// Issues a single <c>PATCH /api/v2/connections/{connectionId}/clients</c> with a one-row
         /// body <c>[{client_id, status}]</c> — Auth0's replacement for the deprecated
         /// <c>enabled_clients</c> field. Success is HTTP 204 (No Content); any other status surfaces
-        /// via <see cref="ThrowFromHttpFailureAsync"/>. No benign-4xx handling is required because
+        /// via <see cref="ThrowFromHttpFailure"/>. No benign-4xx handling is required because
         /// the endpoint is idempotent and returns 204 regardless of prior membership state.
         /// </summary>
         private async Task PatchConnectionClientsAsync(ITenantApiAccess tenantApiAccess, string connectionId,
@@ -1500,7 +1501,7 @@ namespace Alethic.Auth0.Operator.Controllers
                     reconciliationType = driftContext.ReconciliationType.ToString().ToLowerInvariant(),
                     driftReason = driftContext.DriftReason,
                 });
-            await ThrowFromHttpFailureAsync(response, body, operation, connectionId, clientId, cancellationToken);
+            ThrowFromHttpFailure(response, body, operation, connectionId, clientId);
         }
 
         /// <summary>
@@ -1519,12 +1520,15 @@ namespace Alethic.Auth0.Operator.Controllers
                 return req;
             }
 
-            var response = await httpClient.SendAsync(Build(await tenantApiAccess.GetAccessTokenAsync(cancellationToken)),
-                cancellationToken);
+            var firstRequest = Build(await tenantApiAccess.GetAccessTokenAsync(cancellationToken));
+            var response = await httpClient.SendAsync(firstRequest, cancellationToken);
 
             if (response.StatusCode == HttpStatusCode.Unauthorized)
             {
+                // Dispose both the first-attempt request (and its Content stream) and the response
+                // before issuing the retry — otherwise the unread request body leaks until GC.
                 response.Dispose();
+                firstRequest.Dispose();
                 await tenantApiAccess.InvalidateAccessTokenAsync(cancellationToken);
                 response = await httpClient.SendAsync(Build(await tenantApiAccess.GetAccessTokenAsync(cancellationToken)),
                     cancellationToken);
@@ -1561,8 +1565,9 @@ namespace Alethic.Auth0.Operator.Controllers
         /// "Unknown error" branch (CR-1).
         /// Callers own the response lifetime (via <c>using</c>); this method does not dispose it.
         /// </summary>
-        private Task ThrowFromHttpFailureAsync(HttpResponseMessage response, string body, string operation,
-            string connectionId, string clientId, CancellationToken cancellationToken)
+        [DoesNotReturn]
+        private void ThrowFromHttpFailure(HttpResponseMessage response, string body, string operation,
+            string connectionId, string clientId)
         {
             var statusCode = (int)response.StatusCode;
             var apiError = ParseApiErrorOrEmpty(body);

--- a/src/Alethic.Auth0.Operator/Controllers/V1ClientControllerWireModels.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1ClientControllerWireModels.cs
@@ -8,4 +8,5 @@ namespace Alethic.Auth0.Operator.Controllers
         [Newtonsoft.Json.JsonProperty("connections")]
         public List<Connection> Connections { get; set; } = new List<Connection>();
     }
+
 }

--- a/src/Alethic.Auth0.Operator/Controllers/V1ClientControllerWireModels.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1ClientControllerWireModels.cs
@@ -8,5 +8,4 @@ namespace Alethic.Auth0.Operator.Controllers
         [Newtonsoft.Json.JsonProperty("connections")]
         public List<Connection> Connections { get; set; } = new List<Connection>();
     }
-
 }

--- a/src/Alethic.Auth0.Operator/Controllers/V1ClientGrantController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1ClientGrantController.cs
@@ -289,7 +289,7 @@ namespace Alethic.Auth0.Operator.Controllers
             });
             try
             {
-                LogAuth0ApiCall($"Creating Auth0 client grant", Auth0ApiCallType.Write, "A0ClientGrant", "unknown", "unknown", "create_client_grant");
+                LogAuth0ApiCall($"Creating Auth0 client grant", Auth0ApiCallType.Write, "A0ClientGrant", "unknown", "unknown", "create_client_grant", DriftLogContext.FirstReconciliation());
                 var self = await api.ClientGrants.CreateAsync(req, cancellationToken);
                 if (self is null)
                 {
@@ -327,7 +327,7 @@ namespace Alethic.Auth0.Operator.Controllers
         }
 
         /// <inheritdoc />
-        protected override async Task Update(IManagementApiClient api, string id, Hashtable? last, ClientGrantConf conf, List<string> driftingFields, string defaultNamespace, ITenantApiAccess tenantApiAccess, CancellationToken cancellationToken)
+        protected override async Task Update(IManagementApiClient api, string id, Hashtable? last, ClientGrantConf conf, IReadOnlyList<DriftField> driftFields, string defaultNamespace, string entityName, ITenantApiAccess tenantApiAccess, DriftLogContext driftContext, CancellationToken cancellationToken)
         {
             var req = new ClientGrantUpdateRequest();
             req.Scope = conf.Scope?.ToList() ?? new List<string>();
@@ -342,7 +342,7 @@ namespace Alethic.Auth0.Operator.Controllers
             });
             try
             {
-                LogAuth0ApiCall($"Updating Auth0 client grant with ID: {id}", Auth0ApiCallType.Write, "A0ClientGrant", "unknown", "unknown", "update_client_grant");
+                LogAuth0ApiCall($"Updating Auth0 client grant with ID: {id}", Auth0ApiCallType.Write, "A0ClientGrant", "unknown", "unknown", "update_client_grant", driftContext);
                 await api.ClientGrants.UpdateAsync(id, req, cancellationToken);
                 Logger.LogInformationJson($"{EntityTypeName} successfully updated client grant in Auth0 with ID {id}", new
                 {
@@ -377,7 +377,7 @@ namespace Alethic.Auth0.Operator.Controllers
             });
             try
             {
-                LogAuth0ApiCall($"Deleting Auth0 client grant with ID: {id}", Auth0ApiCallType.Write, "A0ClientGrant", id, "unknown", "delete_client_grant");
+                LogAuth0ApiCall($"Deleting Auth0 client grant with ID: {id}", Auth0ApiCallType.Write, "A0ClientGrant", id, "unknown", "delete_client_grant", DriftLogContext.FinalizerDelete());
                 await api.ClientGrants.DeleteAsync(id, cancellationToken);
                 Logger.LogInformationJson($"{EntityTypeName} successfully deleted client grant from Auth0 with ID {id}", new
                 {

--- a/src/Alethic.Auth0.Operator/Controllers/V1ClientGrantController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1ClientGrantController.cs
@@ -289,7 +289,7 @@ namespace Alethic.Auth0.Operator.Controllers
             });
             try
             {
-                LogAuth0ApiCall($"Creating Auth0 client grant", Auth0ApiCallType.Write, "A0ClientGrant", "unknown", "unknown", "create_client_grant", DriftLogContext.FirstReconciliation());
+                LogAuth0Write($"Creating Auth0 client grant", "A0ClientGrant", "unknown", "unknown", "create_client_grant", DriftLogContext.FirstReconciliation());
                 var self = await api.ClientGrants.CreateAsync(req, cancellationToken);
                 if (self is null)
                 {
@@ -342,7 +342,7 @@ namespace Alethic.Auth0.Operator.Controllers
             });
             try
             {
-                LogAuth0ApiCall($"Updating Auth0 client grant with ID: {id}", Auth0ApiCallType.Write, "A0ClientGrant", "unknown", "unknown", "update_client_grant", driftContext);
+                LogAuth0Write($"Updating Auth0 client grant with ID: {id}", "A0ClientGrant", "unknown", "unknown", "update_client_grant", driftContext);
                 await api.ClientGrants.UpdateAsync(id, req, cancellationToken);
                 Logger.LogInformationJson($"{EntityTypeName} successfully updated client grant in Auth0 with ID {id}", new
                 {
@@ -377,7 +377,7 @@ namespace Alethic.Auth0.Operator.Controllers
             });
             try
             {
-                LogAuth0ApiCall($"Deleting Auth0 client grant with ID: {id}", Auth0ApiCallType.Write, "A0ClientGrant", id, "unknown", "delete_client_grant", DriftLogContext.FinalizerDelete());
+                LogAuth0Write($"Deleting Auth0 client grant with ID: {id}", "A0ClientGrant", id, "unknown", "delete_client_grant", DriftLogContext.FinalizerDelete());
                 await api.ClientGrants.DeleteAsync(id, cancellationToken);
                 Logger.LogInformationJson($"{EntityTypeName} successfully deleted client grant from Auth0 with ID {id}", new
                 {

--- a/src/Alethic.Auth0.Operator/Controllers/V1ConnectionController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1ConnectionController.cs
@@ -165,7 +165,7 @@ namespace Alethic.Auth0.Operator.Controllers
                     connectionId = id,
                     operation = "fetch"
                 });
-                LogAuth0ApiCall($"Getting Auth0 connection with ID: {id}", Auth0ApiCallType.Read, "A0Connection", id, defaultNamespace, "retrieve_connection_by_id", driftContext: null);
+                LogAuth0Read($"Getting Auth0 connection with ID: {id}", "A0Connection", id, defaultNamespace, "retrieve_connection_by_id");
                 var self = await api.Connections.GetAsync(id, cancellationToken: cancellationToken);
                 if (self == null)
                 {
@@ -261,7 +261,7 @@ namespace Alethic.Auth0.Operator.Controllers
                     });
                     try
                     {
-                        LogAuth0ApiCall($"Getting Auth0 connection by ID: {connectionId}", Auth0ApiCallType.Read, "A0Connection", entity.Name(), entity.Namespace(), "retrieve_connection_by_id_from_spec", driftContext: null);
+                        LogAuth0Read($"Getting Auth0 connection by ID: {connectionId}", "A0Connection", entity.Name(), entity.Namespace(), "retrieve_connection_by_id_from_spec");
                         var connection = await api.Connections.GetAsync(connectionId, cancellationToken: cancellationToken);
                         Logger.LogInformationJson($"{EntityTypeName} {entity.Namespace()}/{entity.Name()} found existing connection with ID {connectionId} and name {connection.Name}", new
                         {
@@ -338,7 +338,7 @@ namespace Alethic.Auth0.Operator.Controllers
                     connectionName = conf.Name,
                     operation = "search_by_name"
                 });
-                LogAuth0ApiCall($"Listing Auth0 connections to find by name: {conf.Name}", Auth0ApiCallType.Read, "A0Connection", entity.Name(), entity.Namespace(), "list_connections_by_name", driftContext: null);
+                LogAuth0Read($"Listing Auth0 connections to find by name: {conf.Name}", "A0Connection", entity.Name(), entity.Namespace(), "list_connections_by_name");
                 var list = await GetAllConnectionsWithPagination(api, entity, cancellationToken);
                 var self = list.FirstOrDefault(i => string.Equals(i.Name, conf.Name, StringComparison.OrdinalIgnoreCase));
                 if (self is not null)
@@ -394,7 +394,7 @@ namespace Alethic.Auth0.Operator.Controllers
                 req.Strategy = conf.Strategy ?? throw new InvalidOperationException("Strategy is required for connection creation.");
                 req.Options = string.Equals(conf.Strategy, "auth0", StringComparison.OrdinalIgnoreCase) ? (TransformToNewtonsoftJson<ConnectionOptions, global::Auth0.ManagementApi.Models.Connections.ConnectionOptions>(JsonSerializer.Deserialize<ConnectionOptions>(JsonSerializer.Serialize(conf.Options ?? new Hashtable()))) ?? new global::Auth0.ManagementApi.Models.Connections.ConnectionOptions()) : conf.Options ?? new Hashtable();
 
-                LogAuth0ApiCall($"Creating Auth0 connection with name: {conf.Name}", Auth0ApiCallType.Write, "A0Connection", conf.Name ?? "unknown", "unknown", "create_connection", DriftLogContext.FirstReconciliation());
+                LogAuth0Write($"Creating Auth0 connection with name: {conf.Name}", "A0Connection", conf.Name ?? "unknown", "unknown", "create_connection", DriftLogContext.FirstReconciliation());
                 var self = await api.Connections.CreateAsync(req, cancellationToken);
                 if (self is null)
                     throw new InvalidOperationException();
@@ -503,11 +503,11 @@ namespace Alethic.Auth0.Operator.Controllers
                         status = "warning",
                         metadata = req.Metadata
                     });
-                    LogAuth0ApiCall($"Resetting Auth0 connection metadata with ID: {id}", Auth0ApiCallType.Write, "A0Connection", conf.Name ?? "unknown", "unknown", "reset_connection_metadata", driftContext);
+                    LogAuth0Write($"Resetting Auth0 connection metadata with ID: {id}", "A0Connection", conf.Name ?? "unknown", "unknown", "reset_connection_metadata", driftContext);
                     await api.Connections.UpdateAsync(id, new ConnectionUpdateRequest { Metadata = new Hashtable() }, cancellationToken);
                 }
 
-                LogAuth0ApiCall($"Updating Auth0 connection with ID: {id}", Auth0ApiCallType.Write, "A0Connection", conf.Name ?? "unknown", "unknown", "update_connection", driftContext);
+                LogAuth0Write($"Updating Auth0 connection with ID: {id}", "A0Connection", conf.Name ?? "unknown", "unknown", "update_connection", driftContext);
                 await api.Connections.UpdateAsync(id, req, cancellationToken);
                 Logger.LogInformationJson($"{EntityTypeName} successfully updated connection in Auth0 with ID: {id}, name: {conf.Name} and strategy: {conf.Strategy}", new
                 {
@@ -576,7 +576,7 @@ namespace Alethic.Auth0.Operator.Controllers
             });
             try
             {
-                LogAuth0ApiCall($"Deleting Auth0 connection with ID: {id}", Auth0ApiCallType.Write, "A0Connection", id, "unknown", "delete_connection", DriftLogContext.FinalizerDelete());
+                LogAuth0Write($"Deleting Auth0 connection with ID: {id}", "A0Connection", id, "unknown", "delete_connection", DriftLogContext.FinalizerDelete());
                 await api.Connections.DeleteAsync(id, cancellationToken);
                 Logger.LogInformationJson($"{EntityTypeName} successfully deleted connection from Auth0 with ID: {id}", new
                 {

--- a/src/Alethic.Auth0.Operator/Controllers/V1ConnectionController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1ConnectionController.cs
@@ -165,7 +165,7 @@ namespace Alethic.Auth0.Operator.Controllers
                     connectionId = id,
                     operation = "fetch"
                 });
-                LogAuth0ApiCall($"Getting Auth0 connection with ID: {id}", Auth0ApiCallType.Read, "A0Connection", id, defaultNamespace, "retrieve_connection_by_id");
+                LogAuth0ApiCall($"Getting Auth0 connection with ID: {id}", Auth0ApiCallType.Read, "A0Connection", id, defaultNamespace, "retrieve_connection_by_id", driftContext: null);
                 var self = await api.Connections.GetAsync(id, cancellationToken: cancellationToken);
                 if (self == null)
                 {
@@ -261,7 +261,7 @@ namespace Alethic.Auth0.Operator.Controllers
                     });
                     try
                     {
-                        LogAuth0ApiCall($"Getting Auth0 connection by ID: {connectionId}", Auth0ApiCallType.Read, "A0Connection", entity.Name(), entity.Namespace(), "retrieve_connection_by_id_from_spec");
+                        LogAuth0ApiCall($"Getting Auth0 connection by ID: {connectionId}", Auth0ApiCallType.Read, "A0Connection", entity.Name(), entity.Namespace(), "retrieve_connection_by_id_from_spec", driftContext: null);
                         var connection = await api.Connections.GetAsync(connectionId, cancellationToken: cancellationToken);
                         Logger.LogInformationJson($"{EntityTypeName} {entity.Namespace()}/{entity.Name()} found existing connection with ID {connectionId} and name {connection.Name}", new
                         {
@@ -338,7 +338,7 @@ namespace Alethic.Auth0.Operator.Controllers
                     connectionName = conf.Name,
                     operation = "search_by_name"
                 });
-                LogAuth0ApiCall($"Listing Auth0 connections to find by name: {conf.Name}", Auth0ApiCallType.Read, "A0Connection", entity.Name(), entity.Namespace(), "list_connections_by_name");
+                LogAuth0ApiCall($"Listing Auth0 connections to find by name: {conf.Name}", Auth0ApiCallType.Read, "A0Connection", entity.Name(), entity.Namespace(), "list_connections_by_name", driftContext: null);
                 var list = await GetAllConnectionsWithPagination(api, entity, cancellationToken);
                 var self = list.FirstOrDefault(i => string.Equals(i.Name, conf.Name, StringComparison.OrdinalIgnoreCase));
                 if (self is not null)
@@ -394,7 +394,7 @@ namespace Alethic.Auth0.Operator.Controllers
                 req.Strategy = conf.Strategy ?? throw new InvalidOperationException("Strategy is required for connection creation.");
                 req.Options = string.Equals(conf.Strategy, "auth0", StringComparison.OrdinalIgnoreCase) ? (TransformToNewtonsoftJson<ConnectionOptions, global::Auth0.ManagementApi.Models.Connections.ConnectionOptions>(JsonSerializer.Deserialize<ConnectionOptions>(JsonSerializer.Serialize(conf.Options ?? new Hashtable()))) ?? new global::Auth0.ManagementApi.Models.Connections.ConnectionOptions()) : conf.Options ?? new Hashtable();
 
-                LogAuth0ApiCall($"Creating Auth0 connection with name: {conf.Name}", Auth0ApiCallType.Write, "A0Connection", conf.Name ?? "unknown", "unknown", "create_connection");
+                LogAuth0ApiCall($"Creating Auth0 connection with name: {conf.Name}", Auth0ApiCallType.Write, "A0Connection", conf.Name ?? "unknown", "unknown", "create_connection", DriftLogContext.FirstReconciliation());
                 var self = await api.Connections.CreateAsync(req, cancellationToken);
                 if (self is null)
                     throw new InvalidOperationException();
@@ -439,7 +439,7 @@ namespace Alethic.Auth0.Operator.Controllers
         }
 
         /// <inheritdoc />
-        protected override async Task Update(IManagementApiClient api, string id, Hashtable? last, ConnectionConf conf, List<string> driftingFields, string defaultNamespace, ITenantApiAccess tenantApiAccess, CancellationToken cancellationToken)
+        protected override async Task Update(IManagementApiClient api, string id, Hashtable? last, ConnectionConf conf, IReadOnlyList<DriftField> driftFields, string defaultNamespace, string entityName, ITenantApiAccess tenantApiAccess, DriftLogContext driftContext, CancellationToken cancellationToken)
         {
             Logger.LogInformationJson($"{EntityTypeName} updating connection in Auth0 with ID: {id}, name: {conf.Name} and strategy: {conf.Strategy}", new
             {
@@ -503,11 +503,11 @@ namespace Alethic.Auth0.Operator.Controllers
                         status = "warning",
                         metadata = req.Metadata
                     });
-                    LogAuth0ApiCall($"Resetting Auth0 connection metadata with ID: {id}", Auth0ApiCallType.Write, "A0Connection", conf.Name ?? "unknown", "unknown", "reset_connection_metadata");
+                    LogAuth0ApiCall($"Resetting Auth0 connection metadata with ID: {id}", Auth0ApiCallType.Write, "A0Connection", conf.Name ?? "unknown", "unknown", "reset_connection_metadata", driftContext);
                     await api.Connections.UpdateAsync(id, new ConnectionUpdateRequest { Metadata = new Hashtable() }, cancellationToken);
                 }
 
-                LogAuth0ApiCall($"Updating Auth0 connection with ID: {id}", Auth0ApiCallType.Write, "A0Connection", conf.Name ?? "unknown", "unknown", "update_connection");
+                LogAuth0ApiCall($"Updating Auth0 connection with ID: {id}", Auth0ApiCallType.Write, "A0Connection", conf.Name ?? "unknown", "unknown", "update_connection", driftContext);
                 await api.Connections.UpdateAsync(id, req, cancellationToken);
                 Logger.LogInformationJson($"{EntityTypeName} successfully updated connection in Auth0 with ID: {id}, name: {conf.Name} and strategy: {conf.Strategy}", new
                 {
@@ -576,7 +576,7 @@ namespace Alethic.Auth0.Operator.Controllers
             });
             try
             {
-                LogAuth0ApiCall($"Deleting Auth0 connection with ID: {id}", Auth0ApiCallType.Write, "A0Connection", id, "unknown", "delete_connection");
+                LogAuth0ApiCall($"Deleting Auth0 connection with ID: {id}", Auth0ApiCallType.Write, "A0Connection", id, "unknown", "delete_connection", DriftLogContext.FinalizerDelete());
                 await api.Connections.DeleteAsync(id, cancellationToken);
                 Logger.LogInformationJson($"{EntityTypeName} successfully deleted connection from Auth0 with ID: {id}", new
                 {

--- a/src/Alethic.Auth0.Operator/Controllers/V1Controller.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1Controller.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net;
@@ -65,11 +66,21 @@ namespace Alethic.Auth0.Operator.Controllers
 
         static readonly Newtonsoft.Json.JsonSerializer _newtonsoftJsonSerializer = Newtonsoft.Json.JsonSerializer.CreateDefault();
         static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web) { Converters = { new SimplePrimitiveHashtableConverter() } };
+
+        /// <summary>
+        /// Serializer used by <see cref="LogAuth0ApiCall"/>. Matches the camelCase convention applied
+        /// by <see cref="ILoggerExtensions.LogInformationJson"/> et al so investigators see a single
+        /// consistent JSON shape across every structured-log path (including nested
+        /// <see cref="DriftField"/> records).
+        /// </summary>
+        static readonly JsonSerializerOptions _structuredLogJsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = false,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
         static readonly SemaphoreSlim _getTenantApiClient = new(1);
 
-        readonly IKubernetesClient _kube;
         readonly EntityRequeue<TEntity> _requeue;
-        readonly ILogger _logger;
 
         /// <summary>
         /// Initializes a new instance.
@@ -81,9 +92,7 @@ namespace Alethic.Auth0.Operator.Controllers
         public V1Controller(IKubernetesClient kube, EntityRequeue<TEntity> requeue, IMemoryCache cache, ILogger logger)
             : base(kube, logger)
         {
-            _kube = kube ?? throw new ArgumentNullException(nameof(kube));
             _requeue = requeue ?? throw new ArgumentNullException(nameof(requeue));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         /// <summary>
@@ -92,22 +101,16 @@ namespace Alethic.Auth0.Operator.Controllers
         protected abstract string EntityTypeName { get; }
 
         /// <summary>
-        /// Gets the Kubernetes API client.
-        /// </summary>
-        protected IKubernetesClient Kube => _kube;
-
-        /// <summary>
         /// Gets the requeue function for the entity controller.
         /// </summary>
         protected EntityRequeue<TEntity> Requeue => _requeue;
 
         /// <summary>
-        /// Gets the logger.
-        /// </summary>
-        protected ILogger Logger => _logger;
-
-        /// <summary>
         /// Logs Auth0 API call information in JSON format immediately before the API call is made.
+        /// Every <see cref="Auth0ApiCallType.Write"/> call MUST be accompanied by a non-null
+        /// <paramref name="driftContext"/> so the resulting log entry self-describes why the write
+        /// is being issued (first reconciliation, drift, or finalizer cleanup) and which fields drove
+        /// it. Read calls pass a null context and the drift fields are omitted from the JSON payload.
         /// </summary>
         /// <param name="message">The content of the log message</param>
         /// <param name="apiCallType">The type of API call</param>
@@ -115,25 +118,50 @@ namespace Alethic.Auth0.Operator.Controllers
         /// <param name="entityName">The name of the Kubernetes entity</param>
         /// <param name="entityNamespace">The namespace of the Kubernetes entity</param>
         /// <param name="purpose">The purpose of this Auth0 API invocation for better observability</param>
-        protected void LogAuth0ApiCall(string message, Auth0ApiCallType apiCallType, string entityType, string entityName, string entityNamespace, string purpose)
+        /// <param name="driftContext">Why this write is being issued. Required for Write calls.</param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="apiCallType"/> is <see cref="Auth0ApiCallType.Write"/> and
+        /// <paramref name="driftContext"/> is null. Every write must self-describe its trigger.
+        /// </exception>
+        protected void LogAuth0ApiCall(
+            string message,
+            Auth0ApiCallType apiCallType,
+            string entityType,
+            string entityName,
+            string entityNamespace,
+            string purpose,
+            DriftLogContext? driftContext)
         {
-            var logEntry = new
+            if (apiCallType == Auth0ApiCallType.Write && driftContext is null)
+                throw new ArgumentNullException(nameof(driftContext),
+                    "Auth0ApiCallType.Write requires a non-null DriftLogContext so the write log carries reconciliationType/driftFields/driftReason.");
+
+            var logEntry = new Dictionary<string, object?>
             {
-                timestamp = DateTimeOffset.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"),
-                message = message,
-                auth0ApiCallType = apiCallType.ToString().ToLowerInvariant(),
-                entityTypeName = entityType,
-                entityName = entityName,
-                entityNamespace = entityNamespace,
-                auth0ApiCallPurpose = purpose
+                ["timestamp"] = DateTimeOffset.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"),
+                ["message"] = message,
+                ["auth0ApiCallType"] = apiCallType.ToString().ToLowerInvariant(),
+                ["entityTypeName"] = entityType,
+                ["entityName"] = entityName,
+                ["entityNamespace"] = entityNamespace,
+                ["auth0ApiCallPurpose"] = purpose,
             };
-            
-            var jsonLog = System.Text.Json.JsonSerializer.Serialize(logEntry);
-            if (apiCallType == Auth0ApiCallType.Write)
+
+            if (driftContext is not null)
             {
-                Logger.LogWarning(jsonLog);
+                // ReconciliationType + DriftChangeType both carry [JsonConverter(CamelCaseJsonStringEnumConverter)]
+                // so the serializer emits camelCase ("first"/"drift"/"finalizer", "added"/"modified"/"removed").
+                // Boxing the enum as object? lets the converter run instead of stringifying via .ToString().
+                logEntry["reconciliationType"] = driftContext.ReconciliationType;
+                logEntry["driftReason"] = driftContext.DriftReason;
+                logEntry["driftFields"] = driftContext.DriftFields;
             }
-            Logger.LogInformation(jsonLog);
+
+            var jsonLog = System.Text.Json.JsonSerializer.Serialize(logEntry, _structuredLogJsonOptions);
+            var level = apiCallType == Auth0ApiCallType.Write
+                ? LogLevel.Warning
+                : LogLevel.Information;
+            Logger.Log(level, jsonLog);
         }
 
         /// <summary>
@@ -329,7 +357,7 @@ namespace Alethic.Auth0.Operator.Controllers
             // id is specified by reference, lookup identifier
             if (reference.Id is { } id && string.IsNullOrWhiteSpace(id) == false)
             {
-                LogAuth0ApiCall($"Getting Auth0 resource server by reference ID: {id}", Auth0ApiCallType.Read, "A0ResourceServer", id, defaultNamespace, "resolve_resource_server_reference");
+                LogAuth0ApiCall($"Getting Auth0 resource server by reference ID: {id}", Auth0ApiCallType.Read, "A0ResourceServer", id, defaultNamespace, "resolve_resource_server_reference", driftContext: null);
                 var self = await api.ResourceServers.GetAsync(id, cancellationToken);
                 if (self is null)
                     throw new InvalidOperationException($"Failed to resolve ResourceServer reference {id}.");
@@ -752,15 +780,32 @@ namespace Alethic.Auth0.Operator.Controllers
 
         /// <summary>
         /// Returns true for exception types that almost certainly indicate a programmer bug
-        /// (null deref, bad argument, bad cast, missing type) rather than a transient
-        /// runtime / network / API condition. These propagate uncaught so the host's
-        /// crash-loop / paging machinery handles them — silent-requeue would mask them.
+        /// (null deref, bad cast, missing type, missing-key lookup, out-of-range index, malformed
+        /// Auth0 payload) rather than a transient runtime / network / API condition. These
+        /// propagate uncaught so the host's crash-loop / paging machinery handles them — a
+        /// silent requeue would mask them and grow an unbounded retry queue.
+        /// <para>
+        /// V3: <see cref="KeyNotFoundException"/>, <see cref="IndexOutOfRangeException"/>, and
+        /// <see cref="JsonSerializationException"/> (Newtonsoft, used by the Auth0 SDK) are
+        /// included — each represents a code-level invariant violation that requeue cannot
+        /// resolve. A malformed Auth0 payload, in particular, will fail the same way every
+        /// time, so requeueing it just hides the SDK/server-side break.
+        /// </para>
+        /// <para>
+        /// M1: <see cref="ArgumentException"/> is deliberately NOT included. The mandatory-context
+        /// LogAuth0ApiCall contract throws <see cref="ArgumentNullException"/> when a Write call
+        /// forgets its <see cref="DriftLogContext"/>; we want that to requeue (so the operator
+        /// keeps trying other entities) instead of crash-looping the whole pod. Genuine null-deref
+        /// / cast bugs still bypass the catch via the other branches below.
+        /// </para>
         /// </summary>
         private static bool IsProgrammerBug(Exception e) =>
             e is NullReferenceException
-                or ArgumentException // covers ArgumentNullException, ArgumentOutOfRangeException
                 or InvalidCastException
-                or TypeLoadException;
+                or TypeLoadException
+                or KeyNotFoundException
+                or IndexOutOfRangeException
+                or Newtonsoft.Json.JsonSerializationException;
 
         /// <inheritdoc />
         public abstract Task DeletedAsync(TEntity entity, CancellationToken cancellationToken);

--- a/src/Alethic.Auth0.Operator/Controllers/V1Controller.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1Controller.cs
@@ -68,7 +68,7 @@ namespace Alethic.Auth0.Operator.Controllers
         static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web) { Converters = { new SimplePrimitiveHashtableConverter() } };
 
         /// <summary>
-        /// Serializer used by <see cref="LogAuth0ApiCall"/>. Matches the camelCase convention applied
+        /// Serializer used by <see cref="EmitAuth0ApiLog"/>. Matches the camelCase convention applied
         /// by <see cref="ILoggerExtensions.LogInformationJson"/> et al so investigators see a single
         /// consistent JSON shape across every structured-log path (including nested
         /// <see cref="DriftField"/> records).
@@ -106,24 +106,37 @@ namespace Alethic.Auth0.Operator.Controllers
         protected EntityRequeue<TEntity> Requeue => _requeue;
 
         /// <summary>
-        /// Logs Auth0 API call information in JSON format immediately before the API call is made.
-        /// Every <see cref="Auth0ApiCallType.Write"/> call MUST be accompanied by a non-null
-        /// <paramref name="driftContext"/> so the resulting log entry self-describes why the write
-        /// is being issued (first reconciliation, drift, or finalizer cleanup) and which fields drove
-        /// it. Read calls pass a null context and the drift fields are omitted from the JSON payload.
+        /// Logs an Auth0 <em>read</em> API call (GET/list). Emits one structured-JSON entry at
+        /// <see cref="LogLevel.Information"/> with <c>auth0ApiCallType:"read"</c> and no drift
+        /// fields. The Read/Write split exists so the contract — every Write self-describes its
+        /// drift context — is enforced by the type system instead of at runtime.
         /// </summary>
-        /// <param name="message">The content of the log message</param>
-        /// <param name="apiCallType">The type of API call</param>
-        /// <param name="entityType">The Auth0 entity type being operated on</param>
-        /// <param name="entityName">The name of the Kubernetes entity</param>
-        /// <param name="entityNamespace">The namespace of the Kubernetes entity</param>
-        /// <param name="purpose">The purpose of this Auth0 API invocation for better observability</param>
-        /// <param name="driftContext">Why this write is being issued. Required for Write calls.</param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when <paramref name="apiCallType"/> is <see cref="Auth0ApiCallType.Write"/> and
-        /// <paramref name="driftContext"/> is null. Every write must self-describe its trigger.
-        /// </exception>
-        protected void LogAuth0ApiCall(
+        protected void LogAuth0Read(
+            string message,
+            string entityType,
+            string entityName,
+            string entityNamespace,
+            string purpose)
+            => EmitAuth0ApiLog(message, Auth0ApiCallType.Read, entityType, entityName, entityNamespace, purpose, driftContext: null);
+
+        /// <summary>
+        /// Logs an Auth0 <em>write</em> API call (create/update/delete). Emits one structured-JSON
+        /// entry at <see cref="LogLevel.Warning"/> carrying <c>reconciliationType</c>,
+        /// <c>driftReason</c>, and <c>driftFields[]</c> derived from the required
+        /// <paramref name="driftContext"/>. The non-nullable parameter makes "Write without context"
+        /// a compile error — the runtime <c>ArgumentNullException</c> guard that previously enforced
+        /// this is gone, so genuine <see cref="ArgumentException"/> bugs can still crash-loop visibly.
+        /// </summary>
+        protected void LogAuth0Write(
+            string message,
+            string entityType,
+            string entityName,
+            string entityNamespace,
+            string purpose,
+            DriftLogContext driftContext)
+            => EmitAuth0ApiLog(message, Auth0ApiCallType.Write, entityType, entityName, entityNamespace, purpose, driftContext);
+
+        private void EmitAuth0ApiLog(
             string message,
             Auth0ApiCallType apiCallType,
             string entityType,
@@ -132,10 +145,6 @@ namespace Alethic.Auth0.Operator.Controllers
             string purpose,
             DriftLogContext? driftContext)
         {
-            if (apiCallType == Auth0ApiCallType.Write && driftContext is null)
-                throw new ArgumentNullException(nameof(driftContext),
-                    "Auth0ApiCallType.Write requires a non-null DriftLogContext so the write log carries reconciliationType/driftFields/driftReason.");
-
             var logEntry = new Dictionary<string, object?>
             {
                 ["timestamp"] = DateTimeOffset.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"),
@@ -357,7 +366,7 @@ namespace Alethic.Auth0.Operator.Controllers
             // id is specified by reference, lookup identifier
             if (reference.Id is { } id && string.IsNullOrWhiteSpace(id) == false)
             {
-                LogAuth0ApiCall($"Getting Auth0 resource server by reference ID: {id}", Auth0ApiCallType.Read, "A0ResourceServer", id, defaultNamespace, "resolve_resource_server_reference", driftContext: null);
+                LogAuth0Read($"Getting Auth0 resource server by reference ID: {id}", "A0ResourceServer", id, defaultNamespace, "resolve_resource_server_reference");
                 var self = await api.ResourceServers.GetAsync(id, cancellationToken);
                 if (self is null)
                     throw new InvalidOperationException($"Failed to resolve ResourceServer reference {id}.");
@@ -792,17 +801,21 @@ namespace Alethic.Auth0.Operator.Controllers
         /// time, so requeueing it just hides the SDK/server-side break.
         /// </para>
         /// <para>
-        /// M1: <see cref="ArgumentException"/> is deliberately NOT included. The mandatory-context
-        /// LogAuth0ApiCall contract throws <see cref="ArgumentNullException"/> when a Write call
-        /// forgets its <see cref="DriftLogContext"/>; we want that to requeue (so the operator
-        /// keeps trying other entities) instead of crash-looping the whole pod. Genuine null-deref
-        /// / cast bugs still bypass the catch via the other branches below.
+        /// <see cref="ArgumentException"/> (and its <see cref="ArgumentNullException"/> /
+        /// <see cref="ArgumentOutOfRangeException"/> subclasses) is included: a controller passing
+        /// a null/invalid argument to an internal helper is a wiring bug that requeue will never
+        /// resolve. The previous build briefly dropped this entry to cushion a runtime
+        /// <c>ArgumentNullException</c> from <c>LogAuth0ApiCall</c>'s mandatory-context guard;
+        /// that guard has since been removed by splitting the funnel into
+        /// <see cref="LogAuth0Read"/> / <see cref="LogAuth0Write"/>, so the original crash-loud
+        /// invariant is restored.
         /// </para>
         /// </summary>
         private static bool IsProgrammerBug(Exception e) =>
             e is NullReferenceException
                 or InvalidCastException
                 or TypeLoadException
+                or ArgumentException
                 or KeyNotFoundException
                 or IndexOutOfRangeException
                 or Newtonsoft.Json.JsonSerializationException;

--- a/src/Alethic.Auth0.Operator/Controllers/V1Controller.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1Controller.cs
@@ -789,17 +789,9 @@ namespace Alethic.Auth0.Operator.Controllers
 
         /// <summary>
         /// Returns true for exception types that almost certainly indicate a programmer bug
-        /// (null deref, bad cast, missing type, missing-key lookup, out-of-range index, malformed
-        /// Auth0 payload) rather than a transient runtime / network / API condition. These
-        /// propagate uncaught so the host's crash-loop / paging machinery handles them — a
-        /// silent requeue would mask them and grow an unbounded retry queue.
-        /// <para>
-        /// V3: <see cref="KeyNotFoundException"/>, <see cref="IndexOutOfRangeException"/>, and
-        /// <see cref="JsonSerializationException"/> (Newtonsoft, used by the Auth0 SDK) are
-        /// included — each represents a code-level invariant violation that requeue cannot
-        /// resolve. A malformed Auth0 payload, in particular, will fail the same way every
-        /// time, so requeueing it just hides the SDK/server-side break.
-        /// </para>
+        /// (null deref, bad cast, missing type) rather than a transient runtime / network / API
+        /// condition. These propagate uncaught so the host's crash-loop / paging machinery
+        /// handles them — a silent requeue would mask them and grow an unbounded retry queue.
         /// <para>
         /// <see cref="ArgumentException"/> (and its <see cref="ArgumentNullException"/> /
         /// <see cref="ArgumentOutOfRangeException"/> subclasses) is included: a controller passing
@@ -815,10 +807,7 @@ namespace Alethic.Auth0.Operator.Controllers
             e is NullReferenceException
                 or InvalidCastException
                 or TypeLoadException
-                or ArgumentException
-                or KeyNotFoundException
-                or IndexOutOfRangeException
-                or Newtonsoft.Json.JsonSerializationException;
+                or ArgumentException;
 
         /// <inheritdoc />
         public abstract Task DeletedAsync(TEntity entity, CancellationToken cancellationToken);

--- a/src/Alethic.Auth0.Operator/Controllers/V1ResourceServerController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1ResourceServerController.cs
@@ -69,7 +69,7 @@ namespace Alethic.Auth0.Operator.Controllers
                     resourceServerId = id,
                     operation = "fetch"
                 });
-                LogAuth0ApiCall($"Getting Auth0 resource server with ID: {id}", Auth0ApiCallType.Read, "A0ResourceServer", id, defaultNamespace, "retrieve_resource_server_by_id", driftContext: null);
+                LogAuth0Read($"Getting Auth0 resource server with ID: {id}", "A0ResourceServer", id, defaultNamespace, "retrieve_resource_server_by_id");
                 var result = await api.ResourceServers.GetAsync(id, cancellationToken: cancellationToken);
                 Logger.LogInformationJson($"{EntityTypeName} successfully retrieved resource server from Auth0 with ID {id}", new
                 {
@@ -169,7 +169,7 @@ namespace Alethic.Auth0.Operator.Controllers
             });
             try
             {
-                LogAuth0ApiCall($"Creating Auth0 resource server with identifier: {conf.Identifier}", Auth0ApiCallType.Write, "A0ResourceServer", conf.Name ?? "unknown", "unknown", "create_resource_server", DriftLogContext.FirstReconciliation());
+                LogAuth0Write($"Creating Auth0 resource server with identifier: {conf.Identifier}", "A0ResourceServer", conf.Name ?? "unknown", "unknown", "create_resource_server", DriftLogContext.FirstReconciliation());
                 var self = await api.ResourceServers.CreateAsync(TransformToNewtonsoftJson<ResourceServerConf, ResourceServerCreateRequest>(conf), cancellationToken);
                 Logger.LogInformationJson($"{EntityTypeName} successfully created resource server in Auth0 with ID {self.Id} and identifier {self.Identifier}", new
                 {
@@ -208,7 +208,7 @@ namespace Alethic.Auth0.Operator.Controllers
             });
             try
             {
-                LogAuth0ApiCall($"Updating Auth0 resource server with ID: {id}", Auth0ApiCallType.Write, "A0ResourceServer", conf.Name ?? "unknown", "unknown", "update_resource_server", driftContext);
+                LogAuth0Write($"Updating Auth0 resource server with ID: {id}", "A0ResourceServer", conf.Name ?? "unknown", "unknown", "update_resource_server", driftContext);
                 await api.ResourceServers.UpdateAsync(id, TransformToNewtonsoftJson<ResourceServerConf, ResourceServerUpdateRequest>(conf), cancellationToken);
                 Logger.LogInformationJson($"{EntityTypeName} successfully updated resource server in Auth0 with ID {id}", new
                 {
@@ -255,7 +255,7 @@ namespace Alethic.Auth0.Operator.Controllers
             });
             try
             {
-                LogAuth0ApiCall($"Deleting Auth0 resource server with ID: {id}", Auth0ApiCallType.Write, "A0ResourceServer", id, "unknown", "delete_resource_server", DriftLogContext.FinalizerDelete());
+                LogAuth0Write($"Deleting Auth0 resource server with ID: {id}", "A0ResourceServer", id, "unknown", "delete_resource_server", DriftLogContext.FinalizerDelete());
                 await api.ResourceServers.DeleteAsync(id, cancellationToken);
                 Logger.LogInformationJson($"{EntityTypeName} successfully deleted resource server from Auth0 with ID {id}", new
                 {

--- a/src/Alethic.Auth0.Operator/Controllers/V1ResourceServerController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1ResourceServerController.cs
@@ -69,7 +69,7 @@ namespace Alethic.Auth0.Operator.Controllers
                     resourceServerId = id,
                     operation = "fetch"
                 });
-                LogAuth0ApiCall($"Getting Auth0 resource server with ID: {id}", Auth0ApiCallType.Read, "A0ResourceServer", id, defaultNamespace, "retrieve_resource_server_by_id");
+                LogAuth0ApiCall($"Getting Auth0 resource server with ID: {id}", Auth0ApiCallType.Read, "A0ResourceServer", id, defaultNamespace, "retrieve_resource_server_by_id", driftContext: null);
                 var result = await api.ResourceServers.GetAsync(id, cancellationToken: cancellationToken);
                 Logger.LogInformationJson($"{EntityTypeName} successfully retrieved resource server from Auth0 with ID {id}", new
                 {
@@ -169,7 +169,7 @@ namespace Alethic.Auth0.Operator.Controllers
             });
             try
             {
-                LogAuth0ApiCall($"Creating Auth0 resource server with identifier: {conf.Identifier}", Auth0ApiCallType.Write, "A0ResourceServer", conf.Name ?? "unknown", "unknown", "create_resource_server");
+                LogAuth0ApiCall($"Creating Auth0 resource server with identifier: {conf.Identifier}", Auth0ApiCallType.Write, "A0ResourceServer", conf.Name ?? "unknown", "unknown", "create_resource_server", DriftLogContext.FirstReconciliation());
                 var self = await api.ResourceServers.CreateAsync(TransformToNewtonsoftJson<ResourceServerConf, ResourceServerCreateRequest>(conf), cancellationToken);
                 Logger.LogInformationJson($"{EntityTypeName} successfully created resource server in Auth0 with ID {self.Id} and identifier {self.Identifier}", new
                 {
@@ -197,7 +197,7 @@ namespace Alethic.Auth0.Operator.Controllers
         }
 
         /// <inheritdoc />
-        protected override async Task Update(IManagementApiClient api, string id, Hashtable? last, ResourceServerConf conf, List<string> driftingFields, string defaultNamespace, ITenantApiAccess tenantApiAccess, CancellationToken cancellationToken)
+        protected override async Task Update(IManagementApiClient api, string id, Hashtable? last, ResourceServerConf conf, IReadOnlyList<DriftField> driftFields, string defaultNamespace, string entityName, ITenantApiAccess tenantApiAccess, DriftLogContext driftContext, CancellationToken cancellationToken)
         {
             Logger.LogInformationJson($"{EntityTypeName} updating resource server in Auth0 with ID {id} and identifier {conf.Identifier}", new
             {
@@ -208,7 +208,7 @@ namespace Alethic.Auth0.Operator.Controllers
             });
             try
             {
-                LogAuth0ApiCall($"Updating Auth0 resource server with ID: {id}", Auth0ApiCallType.Write, "A0ResourceServer", conf.Name ?? "unknown", "unknown", "update_resource_server");
+                LogAuth0ApiCall($"Updating Auth0 resource server with ID: {id}", Auth0ApiCallType.Write, "A0ResourceServer", conf.Name ?? "unknown", "unknown", "update_resource_server", driftContext);
                 await api.ResourceServers.UpdateAsync(id, TransformToNewtonsoftJson<ResourceServerConf, ResourceServerUpdateRequest>(conf), cancellationToken);
                 Logger.LogInformationJson($"{EntityTypeName} successfully updated resource server in Auth0 with ID {id}", new
                 {
@@ -255,7 +255,7 @@ namespace Alethic.Auth0.Operator.Controllers
             });
             try
             {
-                LogAuth0ApiCall($"Deleting Auth0 resource server with ID: {id}", Auth0ApiCallType.Write, "A0ResourceServer", id, "unknown", "delete_resource_server");
+                LogAuth0ApiCall($"Deleting Auth0 resource server with ID: {id}", Auth0ApiCallType.Write, "A0ResourceServer", id, "unknown", "delete_resource_server", DriftLogContext.FinalizerDelete());
                 await api.ResourceServers.DeleteAsync(id, cancellationToken);
                 Logger.LogInformationJson($"{EntityTypeName} successfully deleted resource server from Auth0 with ID {id}", new
                 {

--- a/src/Alethic.Auth0.Operator/Controllers/V1TenantController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1TenantController.cs
@@ -121,7 +121,8 @@ namespace Alethic.Auth0.Operator.Controllers
 
             // Check if configuration changes need to be applied
             var isFirstReconciliation = entity.Status.LastConf is null;
-            var hasLocalChanges = entity.Spec.Conf is { } currentConf && !isFirstReconciliation && HasConfigurationChanged(entity, entity.Status.LastConf, currentConf);
+            var localDriftFields = new List<DriftField>();
+            var hasLocalChanges = entity.Spec.Conf is { } currentConf && !isFirstReconciliation && HasConfigurationChanged(entity, entity.Status.LastConf, currentConf, out localDriftFields);
             var needsAuth0Fetch = hasLocalChanges || isFirstReconciliation;
 
             TenantSettings? settings = null;
@@ -135,7 +136,7 @@ namespace Alethic.Auth0.Operator.Controllers
                     entityName = entity.Name(),
                     fetchReason = reason
                 });
-                LogAuth0ApiCall($"Getting Auth0 tenant settings", Auth0ApiCallType.Read, "A0Tenant", entity.Name(), entity.Namespace(), "retrieve_tenant_settings");
+                LogAuth0ApiCall($"Getting Auth0 tenant settings", Auth0ApiCallType.Read, "A0Tenant", entity.Name(), entity.Namespace(), "retrieve_tenant_settings", driftContext: null);
                 settings = await api.TenantSettings.GetAsync(cancellationToken: cancellationToken);
                 if (settings is null)
                 {
@@ -161,10 +162,12 @@ namespace Alethic.Auth0.Operator.Controllers
                 // For first reconciliation, check if update is actually needed by comparing with Auth0 state
                 // For subsequent reconciliations, we already know changes exist from local comparison
                 bool needsUpdate;
+                List<DriftField> driftFieldsForWrite;
                 if (isFirstReconciliation)
                 {
                     var settingsHashtable = TransformToSystemTextJson<Hashtable>(settings);
-                    needsUpdate = HasConfigurationChanged(entity, settingsHashtable, conf);
+                    needsUpdate = HasConfigurationChanged(entity, settingsHashtable, conf, out var firstDrift);
+                    driftFieldsForWrite = firstDrift;
                     if (needsUpdate)
                     {
                         Logger.LogWarningJson($"*** {EntityTypeName} {entity.Namespace()}/{entity.Name()} DRIFT DETECTED *** First reconciliation - configuration drift detected between Auth0 and desired state - applying updates", new
@@ -181,6 +184,7 @@ namespace Alethic.Auth0.Operator.Controllers
                 else
                 {
                     needsUpdate = hasLocalChanges;
+                    driftFieldsForWrite = localDriftFields;
                     Logger.LogInformationJson($"{EntityTypeName} {entity.Namespace()}/{entity.Name()} local configuration changes detected - applying updates to Auth0", new
                     {
                         entityTypeName = EntityTypeName,
@@ -221,7 +225,10 @@ namespace Alethic.Auth0.Operator.Controllers
                         // push update to Auth0
                         var req = TransformToNewtonsoftJson<TenantConf, TenantSettingsUpdateRequest>(conf);
                         req.Flags.EnableSSO = null;
-                        LogAuth0ApiCall($"Updating Auth0 tenant settings", Auth0ApiCallType.Write, "A0Tenant", entity.Name(), entity.Namespace(), "update_tenant_settings");
+                        var tenantDriftContext = isFirstReconciliation
+                            ? DriftLogContext.FirstReconciliation()
+                            : DriftLogContext.Drift(driftFieldsForWrite);
+                        LogAuth0ApiCall($"Updating Auth0 tenant settings", Auth0ApiCallType.Write, "A0Tenant", entity.Name(), entity.Namespace(), "update_tenant_settings", tenantDriftContext);
                         settings = await api.TenantSettings.UpdateAsync(req, cancellationToken);
                         Logger.LogInformationJson($"{EntityTypeName} {entity.Namespace()}/{entity.Name()} successfully updated tenant settings in Auth0", new
                         {
@@ -258,7 +265,7 @@ namespace Alethic.Auth0.Operator.Controllers
                     entityName = entity.Name(),
                     operation = "retrieve_final_settings"
                 });
-                LogAuth0ApiCall($"Getting Auth0 tenant settings for status update", Auth0ApiCallType.Read, "A0Tenant", entity.Name(), entity.Namespace(), "retrieve_tenant_settings_for_status");
+                LogAuth0ApiCall($"Getting Auth0 tenant settings for status update", Auth0ApiCallType.Read, "A0Tenant", entity.Name(), entity.Namespace(), "retrieve_tenant_settings_for_status", driftContext: null);
                 settings = await api.TenantSettings.GetAsync(cancellationToken: cancellationToken);
                 entity.Status.LastConf = TransformToSystemTextJson<Hashtable>(settings);
                 try
@@ -299,8 +306,9 @@ namespace Alethic.Auth0.Operator.Controllers
         /// <param name="lastConf">The last known configuration from Auth0</param>
         /// <param name="desiredConf">The desired configuration from the Kubernetes spec</param>
         /// <returns>True if changes are detected, false if configurations match</returns>
-        private bool HasConfigurationChanged(V1Tenant entity, Hashtable? lastConf, TenantConf desiredConf)
+        private bool HasConfigurationChanged(V1Tenant entity, Hashtable? lastConf, TenantConf desiredConf, out List<DriftField> driftFields)
         {
+            driftFields = new List<DriftField>();
             try
             {
                 if (lastConf is null)
@@ -326,7 +334,8 @@ namespace Alethic.Auth0.Operator.Controllers
 
                 if (foundConfigChanges)
                 {
-                    LogConfigurationDifferences(entity, filteredLast, filteredDesired);
+                    driftFields = ComputeDriftFields(filteredLast, filteredDesired);
+                    LogConfigurationDifferences(entity, driftFields);
                 }
 
                 return foundConfigChanges;
@@ -342,6 +351,39 @@ namespace Alethic.Auth0.Operator.Controllers
                 });
                 return true; // Safe fallback: assume changes exist
             }
+        }
+
+        private static List<DriftField> ComputeDriftFields(Hashtable last, Hashtable desired)
+        {
+            var driftFields = new List<DriftField>();
+
+            foreach (DictionaryEntry entry in desired)
+            {
+                var key = entry.Key.ToString()!;
+                if (!last.ContainsKey(entry.Key))
+                {
+                    driftFields.Add(new DriftField(key, DriftChangeType.Added, BeforeValue: null, AfterValue: LogValueFormatter.FormatValueForLogging(entry.Value)));
+                }
+                else if (!AreValuesEqual(entry.Value, last[entry.Key]))
+                {
+                    driftFields.Add(new DriftField(
+                        key,
+                        DriftChangeType.Modified,
+                        BeforeValue: LogValueFormatter.FormatValueForLogging(last[entry.Key]),
+                        AfterValue: LogValueFormatter.FormatValueForLogging(entry.Value)));
+                }
+            }
+
+            foreach (DictionaryEntry entry in last)
+            {
+                if (!desired.ContainsKey(entry.Key))
+                {
+                    var key = entry.Key.ToString()!;
+                    driftFields.Add(new DriftField(key, DriftChangeType.Removed, BeforeValue: LogValueFormatter.FormatValueForLogging(entry.Value), AfterValue: null));
+                }
+            }
+
+            return driftFields;
         }
 
         /// <summary>
@@ -470,37 +512,14 @@ namespace Alethic.Auth0.Operator.Controllers
         /// <param name="entity">The tenant entity</param>
         /// <param name="last">Last known configuration</param>
         /// <param name="desired">Desired configuration</param>
-        private void LogConfigurationDifferences(V1Tenant entity, Hashtable last, Hashtable desired)
+        private void LogConfigurationDifferences(V1Tenant entity, List<DriftField> driftFields)
         {
-            var addedFields = new List<string>();
-            var modifiedFields = new List<string>();
-            var removedFields = new List<string>();
-
-            // Check for added or modified fields
-            foreach (DictionaryEntry entry in desired)
-            {
-                var key = entry.Key.ToString()!;
-                if (!last.ContainsKey(entry.Key))
-                {
-                    addedFields.Add($"{key} = {FormatValueForLogging(entry.Value)}");
-                }
-                else if (!AreValuesEqual(entry.Value, last[entry.Key]))
-                {
-                    var oldValue = FormatValueForLogging(last[entry.Key]);
-                    var newValue = FormatValueForLogging(entry.Value);
-                    modifiedFields.Add($"{key}: {oldValue} → {newValue}");
-                }
-            }
-
-            // Check for removed fields
-            foreach (DictionaryEntry entry in last)
-            {
-                if (!desired.ContainsKey(entry.Key))
-                {
-                    var key = entry.Key.ToString()!;
-                    removedFields.Add($"{key} = {FormatValueForLogging(entry.Value)}");
-                }
-            }
+            var addedFields = driftFields.Where(d => d.ChangeType == DriftChangeType.Added)
+                .Select(d => $"{d.FieldPath} = {d.AfterValue}").ToList();
+            var modifiedFields = driftFields.Where(d => d.ChangeType == DriftChangeType.Modified)
+                .Select(d => $"{d.FieldPath}: {d.BeforeValue} → {d.AfterValue}").ToList();
+            var removedFields = driftFields.Where(d => d.ChangeType == DriftChangeType.Removed)
+                .Select(d => $"{d.FieldPath} = {d.BeforeValue}").ToList();
 
             // Log changes by category with detailed before/after values
             if (addedFields.Count > 0)
@@ -558,48 +577,6 @@ namespace Alethic.Auth0.Operator.Controllers
                     removedCount = removedFields.Count,
                     driftDetected = true
                 });
-            }
-        }
-
-        /// <summary>
-        /// Formats a value for logging, providing detailed representation with truncation for long values.
-        /// </summary>
-        /// <param name="value">Value to format</param>
-        /// <returns>Formatted string representation with type information</returns>
-        private static string FormatValueForLogging(object? value)
-        {
-            if (value is null)
-                return "(null)";
-
-            // Handle different value types with more detail
-            switch (value)
-            {
-                case string stringValue:
-                    var quotedStr = $"\"{stringValue}\"";
-                    return quotedStr.Length > 100 ? $"\"{stringValue[..95]}...\"" : quotedStr;
-
-                case bool boolean:
-                    return boolean.ToString().ToLowerInvariant();
-
-                case int or long or float or double or decimal:
-                    return value.ToString() ?? "(null)";
-
-                case IEnumerable enumerable when value is not string:
-                    var items = enumerable.Cast<object>().Take(5).Select(FormatValueForLogging);
-                    var arrayPreview = string.Join(", ", items);
-                    var count = enumerable.Cast<object>().Count();
-                    return count > 5 ? $"[{arrayPreview}, ...] (total: {count} items)" : $"[{arrayPreview}]";
-
-                case Hashtable hashtable:
-                    var entries = hashtable.Cast<DictionaryEntry>().Take(3)
-                        .Select(entry => $"{entry.Key}: {FormatValueForLogging(entry.Value)}");
-                    var hashPreview = string.Join(", ", entries);
-                    return hashtable.Count > 3 ? $"{{{hashPreview}, ...}} (total: {hashtable.Count} fields)" : $"{{{hashPreview}}}";
-
-                default:
-                    var objectStr = value.ToString() ?? "(null)";
-                    var typeName = value.GetType().Name;
-                    return objectStr.Length > 80 ? $"({typeName}) {objectStr[..75]}..." : $"({typeName}) {objectStr}";
             }
         }
 

--- a/src/Alethic.Auth0.Operator/Controllers/V1TenantController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1TenantController.cs
@@ -136,7 +136,7 @@ namespace Alethic.Auth0.Operator.Controllers
                     entityName = entity.Name(),
                     fetchReason = reason
                 });
-                LogAuth0ApiCall($"Getting Auth0 tenant settings", Auth0ApiCallType.Read, "A0Tenant", entity.Name(), entity.Namespace(), "retrieve_tenant_settings", driftContext: null);
+                LogAuth0Read($"Getting Auth0 tenant settings", "A0Tenant", entity.Name(), entity.Namespace(), "retrieve_tenant_settings");
                 settings = await api.TenantSettings.GetAsync(cancellationToken: cancellationToken);
                 if (settings is null)
                 {
@@ -228,7 +228,7 @@ namespace Alethic.Auth0.Operator.Controllers
                         var tenantDriftContext = isFirstReconciliation
                             ? DriftLogContext.FirstReconciliation()
                             : DriftLogContext.Drift(driftFieldsForWrite);
-                        LogAuth0ApiCall($"Updating Auth0 tenant settings", Auth0ApiCallType.Write, "A0Tenant", entity.Name(), entity.Namespace(), "update_tenant_settings", tenantDriftContext);
+                        LogAuth0Write($"Updating Auth0 tenant settings", "A0Tenant", entity.Name(), entity.Namespace(), "update_tenant_settings", tenantDriftContext);
                         settings = await api.TenantSettings.UpdateAsync(req, cancellationToken);
                         Logger.LogInformationJson($"{EntityTypeName} {entity.Namespace()}/{entity.Name()} successfully updated tenant settings in Auth0", new
                         {
@@ -265,7 +265,7 @@ namespace Alethic.Auth0.Operator.Controllers
                     entityName = entity.Name(),
                     operation = "retrieve_final_settings"
                 });
-                LogAuth0ApiCall($"Getting Auth0 tenant settings for status update", Auth0ApiCallType.Read, "A0Tenant", entity.Name(), entity.Namespace(), "retrieve_tenant_settings_for_status", driftContext: null);
+                LogAuth0Read($"Getting Auth0 tenant settings for status update", "A0Tenant", entity.Name(), entity.Namespace(), "retrieve_tenant_settings_for_status");
                 settings = await api.TenantSettings.GetAsync(cancellationToken: cancellationToken);
                 entity.Status.LastConf = TransformToSystemTextJson<Hashtable>(settings);
                 try
@@ -362,15 +362,15 @@ namespace Alethic.Auth0.Operator.Controllers
                 var key = entry.Key.ToString()!;
                 if (!last.ContainsKey(entry.Key))
                 {
-                    driftFields.Add(new DriftField(key, DriftChangeType.Added, BeforeValue: null, AfterValue: LogValueFormatter.FormatValueForLogging(entry.Value)));
+                    driftFields.Add(new DriftField(key, DriftChangeType.Added, BeforeValue: null, AfterValue: RedactedOrFormat(key, entry.Value)));
                 }
                 else if (!AreValuesEqual(entry.Value, last[entry.Key]))
                 {
                     driftFields.Add(new DriftField(
                         key,
                         DriftChangeType.Modified,
-                        BeforeValue: LogValueFormatter.FormatValueForLogging(last[entry.Key]),
-                        AfterValue: LogValueFormatter.FormatValueForLogging(entry.Value)));
+                        BeforeValue: RedactedOrFormat(key, last[entry.Key]),
+                        AfterValue: RedactedOrFormat(key, entry.Value)));
                 }
             }
 
@@ -379,12 +379,22 @@ namespace Alethic.Auth0.Operator.Controllers
                 if (!desired.ContainsKey(entry.Key))
                 {
                     var key = entry.Key.ToString()!;
-                    driftFields.Add(new DriftField(key, DriftChangeType.Removed, BeforeValue: LogValueFormatter.FormatValueForLogging(entry.Value), AfterValue: null));
+                    driftFields.Add(new DriftField(key, DriftChangeType.Removed, BeforeValue: RedactedOrFormat(key, entry.Value), AfterValue: null));
                 }
             }
 
             return driftFields;
         }
+
+        /// <summary>
+        /// Wraps <see cref="LogValueFormatter.FormatValueForLogging"/> with a top-level
+        /// key-aware redaction step so sensitive Auth0 tenant fields (signing keys, secrets,
+        /// etc.) never reach the structured drift-log payload.
+        /// </summary>
+        private static string RedactedOrFormat(string key, object? value)
+            => LogValueFormatter.IsSensitiveKey(key)
+                ? LogValueFormatter.RedactedPlaceholder
+                : LogValueFormatter.FormatValueForLogging(value);
 
         /// <summary>
         /// Filters fields for comparison based on the tenant-specific fields we track.

--- a/src/Alethic.Auth0.Operator/Controllers/V1TenantEntityController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1TenantEntityController.cs
@@ -377,8 +377,8 @@ namespace Alethic.Auth0.Operator.Controllers
 
         /// <summary>
         /// Delays (in milliseconds) used between attempts of the K8s 409-Conflict retry helper.
-        /// Four attempts total — caller's first attempt + up to three retries — with jittered
-        /// 100 / 400 / 1600 ms pauses between attempts. Plain "100/400/1600 ms ±25% jitter".
+        /// Three retries after the initial attempt (4 total). Delays before each retry:
+        /// retry 1: ~100ms, retry 2: ~400ms, retry 3: ~1600ms (each ±25% jitter).
         /// </summary>
         private static readonly int[] KubeConflictRetryDelaysMs = new[] { 100, 400, 1600 };
 

--- a/src/Alethic.Auth0.Operator/Controllers/V1TenantEntityController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1TenantEntityController.cs
@@ -467,8 +467,11 @@ namespace Alethic.Auth0.Operator.Controllers
             // H5: Every metadata key written by this operator lives under the
             // `kubernetes.auth0.com/` prefix (current-client-id, current-tenant-ref,
             // previous-client-id, previous-tenant-ref, tenant-uid, tenant-name,
-            // tenant-change-retry-count, partition, operator). Restricting the overlay
+            // tenant-change-retry-count, partition). Restricting the overlay
             // to this prefix is sufficient — no other operator-owned key escapes.
+            // For reference (not an annotation key): the EventSource `reportingController`
+            // value is `kubernetes.auth0.com/operator`, which shares the prefix but is
+            // surfaced via Kubernetes events, not metadata.
             const string operatorPrefix = "kubernetes.auth0.com/";
 
             var rmd = refetched.EnsureMetadata();
@@ -497,7 +500,9 @@ namespace Alethic.Auth0.Operator.Controllers
                 }
             }
 
-            // Overlay labels (symmetric)
+            // Overlay labels (symmetric).
+            // Defensive — no operator code currently writes labels; this branch is here so
+            // future label writes are auto-protected by the same allowlist without re-deriving it.
             var localLabels = local.Metadata?.Labels;
             if (localLabels is not null)
             {

--- a/src/Alethic.Auth0.Operator/Controllers/V1TenantEntityController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1TenantEntityController.cs
@@ -377,7 +377,7 @@ namespace Alethic.Auth0.Operator.Controllers
 
         /// <summary>
         /// Delays (in milliseconds) used between attempts of the K8s 409-Conflict retry helper.
-        /// Three attempts total — caller's first attempt + up to two retries — with jittered
+        /// Four attempts total — caller's first attempt + up to three retries — with jittered
         /// 100 / 400 / 1600 ms pauses between attempts. Plain "100/400/1600 ms ±25% jitter".
         /// </summary>
         private static readonly int[] KubeConflictRetryDelaysMs = new[] { 100, 400, 1600 };
@@ -1523,7 +1523,7 @@ namespace Alethic.Auth0.Operator.Controllers
                 var key = entry.Key.ToString()!;
                 if (!last.ContainsKey(entry.Key))
                 {
-                    driftFields.Add(new DriftField(key, DriftChangeType.Added, BeforeValue: null, AfterValue: LogValueFormatter.FormatValueForLogging(entry.Value)));
+                    driftFields.Add(new DriftField(key, DriftChangeType.Added, BeforeValue: null, AfterValue: RedactedOrFormat(key, entry.Value)));
                 }
                 else
                 {
@@ -1532,8 +1532,8 @@ namespace Alethic.Auth0.Operator.Controllers
 
                     if (!AreValuesEqual(filteredDesired, filteredAuth0))
                     {
-                        var oldValue = LogValueFormatter.FormatValueForLogging(filteredAuth0);
-                        var newValue = LogValueFormatter.FormatValueForLogging(filteredDesired);
+                        var oldValue = RedactedOrFormat(key, filteredAuth0);
+                        var newValue = RedactedOrFormat(key, filteredDesired);
                         driftFields.Add(new DriftField(key, DriftChangeType.Modified, BeforeValue: oldValue, AfterValue: newValue));
                     }
                 }
@@ -1545,12 +1545,23 @@ namespace Alethic.Auth0.Operator.Controllers
                 if (!desired.ContainsKey(entry.Key))
                 {
                     var key = entry.Key.ToString()!;
-                    driftFields.Add(new DriftField(key, DriftChangeType.Removed, BeforeValue: LogValueFormatter.FormatValueForLogging(entry.Value), AfterValue: null));
+                    driftFields.Add(new DriftField(key, DriftChangeType.Removed, BeforeValue: RedactedOrFormat(key, entry.Value), AfterValue: null));
                 }
             }
 
             return driftFields;
         }
+
+        /// <summary>
+        /// Wraps <see cref="LogValueFormatter.FormatValueForLogging"/> with a top-level
+        /// key-aware redaction step. Catches whole-field secrets (e.g. a top-level
+        /// <c>client_secret</c> string) that the hashtable-recursion redaction in
+        /// <see cref="LogValueFormatter"/> only handles for nested entries.
+        /// </summary>
+        private static string RedactedOrFormat(string key, object? value)
+            => LogValueFormatter.IsSensitiveKey(key)
+                ? LogValueFormatter.RedactedPlaceholder
+                : LogValueFormatter.FormatValueForLogging(value);
 
         /// <summary>
         /// Logs detected configuration differences with detailed field-by-field changes.

--- a/src/Alethic.Auth0.Operator/Controllers/V1TenantEntityController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1TenantEntityController.cs
@@ -101,7 +101,7 @@ namespace Alethic.Auth0.Operator.Controllers
         /// <param name="tenantApiAccess">Tenant API access for credentials and tokens</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A task representing the asynchronous update operation</returns>
-        protected abstract Task Update(IManagementApiClient api, string id, Hashtable? last, TConf conf, List<string> driftingFields, string defaultNamespace, ITenantApiAccess tenantApiAccess, CancellationToken cancellationToken);
+        protected abstract Task Update(IManagementApiClient api, string id, Hashtable? last, TConf conf, IReadOnlyList<DriftField> driftFields, string defaultNamespace, string entityName, ITenantApiAccess tenantApiAccess, DriftLogContext driftContext, CancellationToken cancellationToken);
 
 
         /// <summary>
@@ -377,8 +377,8 @@ namespace Alethic.Auth0.Operator.Controllers
 
         /// <summary>
         /// Delays (in milliseconds) used between attempts of the K8s 409-Conflict retry helper.
-        /// Four attempts total — caller's first attempt + up to three retries (KubeConflictRetryDelaysMs
-        /// has 3 entries: 100 / 400 / 1600 ms with ±25% jitter between attempts).
+        /// Three attempts total — caller's first attempt + up to two retries — with jittered
+        /// 100 / 400 / 1600 ms pauses between attempts. Plain "100/400/1600 ms ±25% jitter".
         /// </summary>
         private static readonly int[] KubeConflictRetryDelaysMs = new[] { 100, 400, 1600 };
 
@@ -467,11 +467,8 @@ namespace Alethic.Auth0.Operator.Controllers
             // H5: Every metadata key written by this operator lives under the
             // `kubernetes.auth0.com/` prefix (current-client-id, current-tenant-ref,
             // previous-client-id, previous-tenant-ref, tenant-uid, tenant-name,
-            // tenant-change-retry-count, partition). Restricting the overlay
+            // tenant-change-retry-count, partition, operator). Restricting the overlay
             // to this prefix is sufficient — no other operator-owned key escapes.
-            // For reference (not an annotation key): the EventSource `reportingController`
-            // value is `kubernetes.auth0.com/operator`, which shares the prefix but is
-            // surfaced via Kubernetes events, not metadata.
             const string operatorPrefix = "kubernetes.auth0.com/";
 
             var rmd = refetched.EnsureMetadata();
@@ -500,9 +497,7 @@ namespace Alethic.Auth0.Operator.Controllers
                 }
             }
 
-            // Overlay labels (symmetric).
-            // Defensive — no operator code currently writes labels; this branch is here so
-            // future label writes are auto-protected by the same allowlist without re-deriving it.
+            // Overlay labels (symmetric)
             var localLabels = local.Metadata?.Labels;
             if (localLabels is not null)
             {
@@ -732,11 +727,14 @@ namespace Alethic.Auth0.Operator.Controllers
                 return lastConf;
             }
 
-            var (needsUpdate, driftingFields) = DetermineIfUpdateIsNeeded(entity, lastConf, conf);
+            var (needsUpdate, driftFields, isFirstReconciliation) = DetermineIfUpdateIsNeeded(entity, lastConf, conf);
 
             if (needsUpdate)
             {
-                var processedConf = await PerformUpdate(entity, tenantApiAccess, api, lastConf, conf, driftingFields, cancellationToken);
+                var driftContext = isFirstReconciliation
+                    ? DriftLogContext.FirstReconciliation()
+                    : DriftLogContext.Drift(driftFields);
+                var processedConf = await PerformUpdate(entity, tenantApiAccess, api, lastConf, conf, driftFields, driftContext, cancellationToken);
 
                 return processedConf;
             }
@@ -754,28 +752,17 @@ namespace Alethic.Auth0.Operator.Controllers
             });
         }
 
-        private (bool needsUpdate, List<string> driftingFields) DetermineIfUpdateIsNeeded(TEntity entity, Hashtable? lastConf, TConf conf)
+        private (bool needsUpdate, List<DriftField> driftFields, bool isFirstReconciliation) DetermineIfUpdateIsNeeded(TEntity entity, Hashtable? lastConf, TConf conf)
         {
             var isFirstReconciliation = entity.Status.LastConf is null;
 
-            bool needsUpdate;
-            List<string> driftingFields;
+            var (needsUpdate, driftFields) = HasConfigurationChanged(entity, lastConf, conf);
             if (isFirstReconciliation)
-            {
-                var (needsUpdateResult, driftingFieldsResult) = HasConfigurationChanged(entity, lastConf, conf);
-                needsUpdate = needsUpdateResult;
-                driftingFields = driftingFieldsResult;
                 LogFirstReconciliationDecision(entity, needsUpdate);
-            }
             else
-            {
-                var (needsUpdateResult, driftingFieldsResult) = HasConfigurationChanged(entity, lastConf, conf);
-                needsUpdate = needsUpdateResult;
-                driftingFields = driftingFieldsResult;
                 LogSubsequentReconciliationDecision(entity, needsUpdate);
-            }
 
-            return (needsUpdate, driftingFields);
+            return (needsUpdate, driftFields, isFirstReconciliation);
         }
 
         private void LogFirstReconciliationDecision(TEntity entity, bool needsUpdate)
@@ -831,9 +818,9 @@ namespace Alethic.Auth0.Operator.Controllers
             }
         }
 
-        private async Task<Hashtable> PerformUpdate(TEntity entity, ITenantApiAccess tenantApiAccess, IManagementApiClient api, Hashtable? lastConf, TConf conf, List<string> driftingFields, CancellationToken cancellationToken)
+        private async Task<Hashtable> PerformUpdate(TEntity entity, ITenantApiAccess tenantApiAccess, IManagementApiClient api, Hashtable? lastConf, TConf conf, List<DriftField> driftFields, DriftLogContext driftContext, CancellationToken cancellationToken)
         {
-            await Update(api, entity.Status.Id ?? throw new InvalidOperationException($"Entity {entity.Namespace()}/{entity.Name()} has no ID in status."), lastConf, conf, driftingFields, entity.Namespace(), tenantApiAccess, cancellationToken);
+            await Update(api, entity.Status.Id ?? throw new InvalidOperationException($"Entity {entity.Namespace()}/{entity.Name()} has no ID in status."), lastConf, conf, driftFields, entity.Namespace(), entity.Name(), tenantApiAccess, driftContext, cancellationToken);
 
             // Update lastConf to reflect the applied configuration to prevent false drift detection
             var appliedJson = TransformToNewtonsoftJson<TConf, object>(conf);
@@ -1204,7 +1191,7 @@ namespace Alethic.Auth0.Operator.Controllers
         /// <param name="lastConf">The last known configuration from Auth0</param>
         /// <param name="desiredConf">The desired configuration from the Kubernetes spec</param>
         /// <returns>True if changes are detected, false if configurations match</returns>
-        private (bool configurationChanged, List<string> driftingFields) HasConfigurationChanged(TEntity entity, Hashtable? lastConf, TConf desiredConf)
+        private (bool configurationChanged, List<DriftField> driftFields) HasConfigurationChanged(TEntity entity, Hashtable? lastConf, TConf desiredConf)
         {
             try
             {
@@ -1226,9 +1213,13 @@ namespace Alethic.Auth0.Operator.Controllers
                         assumingChanges = true
                     });
 
-                    // return all fields from desiredConf
-                    var desiredConfFields = desiredHashtable.Keys.Cast<string>().ToList();
-                    return (true, desiredConfFields);
+                    // Synthesize an Added-only drift list from the desired keys so consumers
+                    // (V1ClientController's selective-update routing) can still inspect which
+                    // top-level fields are involved.
+                    var firstReconcileFields = desiredHashtable.Keys.Cast<string>()
+                        .Select(k => new DriftField(k, DriftChangeType.Added, BeforeValue: null, AfterValue: null))
+                        .ToList();
+                    return (true, firstReconcileFields);
                 }
 
                 // Filter fields based on the entity's drift detection configuration
@@ -1242,14 +1233,14 @@ namespace Alethic.Auth0.Operator.Controllers
                 // Compare the filtered configurations
                 var result = !AreHashtablesEqual(nestedFilteredLast, filteredDesired);
 
-                var driftFieldDetails = new List<DriftFieldDetails>();
+                var driftFields = new List<DriftField>();
                 if (result)
                 {
-                    driftFieldDetails = GetDriftFieldDetails(entity, filteredLast, filteredDesired);
-                    LogConfigurationDifferences(entity, driftFieldDetails);
+                    driftFields = GetDriftFieldDetails(entity, filteredLast, filteredDesired);
+                    LogConfigurationDifferences(entity, driftFields);
                 }
 
-                return (result, driftFieldDetails.Select(d => d.FieldName!).ToList());
+                return (result, driftFields);
             }
             catch (Exception ex)
             {
@@ -1260,7 +1251,7 @@ namespace Alethic.Auth0.Operator.Controllers
                     errorMessage = ex.Message,
                     assumingChanges = true
                 });
-                return (true, new List<string>()); // Safe fallback: assume changes exist
+                return (true, new List<DriftField>()); // Safe fallback: assume changes exist
             }
         }
 
@@ -1522,29 +1513,9 @@ namespace Alethic.Auth0.Operator.Controllers
             return left.Equals(right);
         }
 
-        private enum DriftFieldType
+        private List<DriftField> GetDriftFieldDetails(TEntity entity, Hashtable last, Hashtable desired)
         {
-            Added,
-            Modified,
-            Removed
-        }
-
-        private class DriftFieldDetails
-        {
-            public DriftFieldType FieldType { get; set; }
-            public string? FieldName { get; set; }
-            public object? OldValue { get; set; }
-            public object? NewValue { get; set; }
-
-            public override string ToString()
-            {
-                return $"{FieldName} = {OldValue} → {NewValue}";
-            }
-        }
-
-        private List<DriftFieldDetails> GetDriftFieldDetails(TEntity entity, Hashtable last, Hashtable desired)
-        {
-            var driftFieldDetails = new List<DriftFieldDetails>();
+            var driftFields = new List<DriftField>();
 
             // Check for added or modified fields
             foreach (DictionaryEntry entry in desired)
@@ -1552,7 +1523,7 @@ namespace Alethic.Auth0.Operator.Controllers
                 var key = entry.Key.ToString()!;
                 if (!last.ContainsKey(entry.Key))
                 {
-                    driftFieldDetails.Add(new DriftFieldDetails { FieldType = DriftFieldType.Added, FieldName = key, OldValue = null, NewValue = entry.Value });
+                    driftFields.Add(new DriftField(key, DriftChangeType.Added, BeforeValue: null, AfterValue: LogValueFormatter.FormatValueForLogging(entry.Value)));
                 }
                 else
                 {
@@ -1561,9 +1532,9 @@ namespace Alethic.Auth0.Operator.Controllers
 
                     if (!AreValuesEqual(filteredDesired, filteredAuth0))
                     {
-                        var oldValue = FormatValueForLogging(filteredAuth0);
-                        var newValue = FormatValueForLogging(filteredDesired);
-                        driftFieldDetails.Add(new DriftFieldDetails { FieldType = DriftFieldType.Modified, FieldName = key, OldValue = oldValue, NewValue = newValue });
+                        var oldValue = LogValueFormatter.FormatValueForLogging(filteredAuth0);
+                        var newValue = LogValueFormatter.FormatValueForLogging(filteredDesired);
+                        driftFields.Add(new DriftField(key, DriftChangeType.Modified, BeforeValue: oldValue, AfterValue: newValue));
                     }
                 }
             }
@@ -1574,23 +1545,23 @@ namespace Alethic.Auth0.Operator.Controllers
                 if (!desired.ContainsKey(entry.Key))
                 {
                     var key = entry.Key.ToString()!;
-                    driftFieldDetails.Add(new DriftFieldDetails { FieldType = DriftFieldType.Removed, FieldName = key, OldValue = entry.Value, NewValue = null });
+                    driftFields.Add(new DriftField(key, DriftChangeType.Removed, BeforeValue: LogValueFormatter.FormatValueForLogging(entry.Value), AfterValue: null));
                 }
             }
 
-            return driftFieldDetails;
+            return driftFields;
         }
 
         /// <summary>
         /// Logs detected configuration differences with detailed field-by-field changes.
         /// </summary>
         /// <param name="entity">The entity</param>
-        /// <param name="driftFieldDetails">The drift field details</param>
-        private void LogConfigurationDifferences(TEntity entity, List<DriftFieldDetails> driftFieldDetails)
+        /// <param name="driftFields">The drift field details</param>
+        private void LogConfigurationDifferences(TEntity entity, List<DriftField> driftFields)
         {
-            var addedFields = driftFieldDetails.Where(d => d.FieldType == DriftFieldType.Added).ToList();
-            var modifiedFields = driftFieldDetails.Where(d => d.FieldType == DriftFieldType.Modified).ToList();
-            var removedFields = driftFieldDetails.Where(d => d.FieldType == DriftFieldType.Removed).ToList();
+            var addedFields = driftFields.Where(d => d.ChangeType == DriftChangeType.Added).ToList();
+            var modifiedFields = driftFields.Where(d => d.ChangeType == DriftChangeType.Modified).ToList();
+            var removedFields = driftFields.Where(d => d.ChangeType == DriftChangeType.Removed).ToList();
 
             // Log changes by category with detailed before/after values
             if (addedFields.Count > 0)
@@ -1648,50 +1619,6 @@ namespace Alethic.Auth0.Operator.Controllers
                     removedCount = removedFields.Count,
                     driftDetected = true
                 });
-            }
-        }
-
-        /// <summary>
-        /// Formats a value for logging, providing detailed representation with truncation for long values.
-        /// </summary>
-        /// <param name="value">Value to format</param>
-        /// <returns>Formatted string representation with type information</returns>
-        private static string FormatValueForLogging(object? value)
-        {
-            if (value is null)
-                return "(null)";
-
-            // Handle different value types with more detail
-            // IMPORTANT: Check Hashtable before IEnumerable since Hashtable implements IEnumerable
-            switch (value)
-            {
-                case string stringValue:
-                    var quotedStr = $"\"{stringValue}\"";
-                    return quotedStr.Length > 100 ? $"\"{stringValue[..95]}...\"" : quotedStr;
-
-                case bool boolean:
-                    return boolean.ToString().ToLowerInvariant();
-
-                case int or long or float or double or decimal:
-                    return value.ToString() ?? "(null)";
-
-                case Hashtable hashtable:
-                    // Show up to 10 entries for Hashtables (useful for debugging options drift)
-                    var entries = hashtable.Cast<DictionaryEntry>().Take(10)
-                        .Select(entry => $"{entry.Key}: {FormatValueForLogging(entry.Value)}");
-                    var hashPreview = string.Join(", ", entries);
-                    return hashtable.Count > 10 ? $"{{{hashPreview}, ...}} (total: {hashtable.Count} fields)" : $"{{{hashPreview}}}";
-
-                case IEnumerable enumerable when value is not string:
-                    var items = enumerable.Cast<object>().Take(5).Select(FormatValueForLogging);
-                    var arrayPreview = string.Join(", ", items);
-                    var count = enumerable.Cast<object>().Count();
-                    return count > 5 ? $"[{arrayPreview}, ...] (total: {count} items)" : $"[{arrayPreview}]";
-
-                default:
-                    var objectStr = value.ToString() ?? "(null)";
-                    var typeName = value.GetType().Name;
-                    return objectStr.Length > 80 ? $"({typeName}) {objectStr[..75]}..." : $"({typeName}) {objectStr}";
             }
         }
 


### PR DESCRIPTION
## Summary

Internal code-review follow-up on `LA-RF-81-followup-logging`. Closes every Critical / High / Medium finding from the internal review.

- **Critical**: redact secrets in the connection-options drift log (key-aware denylist in `LogValueFormatter` + `RedactedOrFormat` wrappers in `GetDriftFieldDetails` / `ComputeDriftFields`)
- **High**: `DriftField` constructor guard rejects secret-shaped `BeforeValue` / `AfterValue`
- **High**: split `LogAuth0ApiCall` into `LogAuth0Read` / `LogAuth0Write` (non-nullable `DriftLogContext` — compile-time contract; runtime `ArgumentNullException` removed)
- **High**: restore `ArgumentException` to `IsProgrammerBug` allowlist now that the runtime guard is gone
- **Medium**: visibility asymmetry — `CamelCaseJsonStringEnumConverter` made `public` (making the enums `internal` hits CS0051 on `protected abstract` signatures)
- **Medium**: new test locks `reconciliationType` / `changeType` as camelCase strings, not numbers
- **Medium**: document intentional `AfterValue=null` on first-reconcile synthesis (selective-update consumer reads `FieldPath` only)
- **Medium**: drop `connectionId` from membership drift `FieldPath` (bounded Datadog facet cardinality)
- **Medium**: symmetric enum serialization in `PatchConnectionClientsAsync` failure log
- **Low**: fix `KubeConflictRetryDelaysMs` comment regression (four attempts, not three)

Three remaining Low + three Suggestion items deferred per human review.

## Test plan

- [x] `dotnet build Alethic.Auth0.Operator.sln` — 8 projects, 0 errors, 0 warnings
- [x] `dotnet test src/Alethic.Auth0.Operator.Tests/` — 42 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)