### PR TITLE
RF-81 — Resolve A0Tenant/A0Connection drift false-positives, rate-limit observability, and follow-ups

### DIFF
--- a/src/Alethic.Auth0.Operator.Tests/Controllers/DriftFieldTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Controllers/DriftFieldTests.cs
@@ -1,0 +1,80 @@
+using System;
+
+using Alethic.Auth0.Operator.Controllers;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Alethic.Auth0.Operator.Tests.Controllers
+{
+    /// <summary>
+    /// Locks the <see cref="DriftField.EnsureNoSecretShape"/> guard contract against the recurring
+    /// false-positive that fired on the <c>waad</c>-connection enum value
+    /// <c>token_endpoint_auth_method</c>. The guard substring-matches on <c>"client_secret"</c> to
+    /// catch unredacted secrets, but the same substring is a valid OAuth enum value
+    /// (<c>client_secret_post</c>/<c>_basic</c>/<c>_jwt</c>). The fix allowlists the *exact quoted*
+    /// rendered form so user-controlled string fields that merely contain the same substring still
+    /// trip the guard (we'd rather fail loud than under-redact).
+    /// </summary>
+    [TestClass]
+    public class DriftFieldTests
+    {
+        [TestMethod]
+        public void Constructor_AllowsTokenEndpointAuthMethodEnumValues()
+        {
+            // Both quoted enum values must construct without throwing — this is the production
+            // false-positive on avfc-azuread-test-eu that we're unblocking.
+            var field = new DriftField(
+                "token_endpoint_auth_method",
+                DriftChangeType.Modified,
+                "\"client_secret_basic\"",
+                "\"client_secret_post\"");
+
+            Assert.AreEqual("token_endpoint_auth_method", field.FieldPath);
+            Assert.AreEqual("\"client_secret_basic\"", field.BeforeValue);
+            Assert.AreEqual("\"client_secret_post\"", field.AfterValue);
+        }
+
+        [TestMethod]
+        public void Constructor_AllowsClientSecretJwtEnumValue()
+        {
+            // client_secret_jwt is not currently in our TokenEndpointAuthMethod enum but is a
+            // valid Auth0-returned value (OIDC core spec). Pre-emptive allowlist.
+            var field = new DriftField(
+                "token_endpoint_auth_method",
+                DriftChangeType.Modified,
+                "\"client_secret_basic\"",
+                "\"client_secret_jwt\"");
+
+            Assert.AreEqual("\"client_secret_jwt\"", field.AfterValue);
+        }
+
+        [TestMethod]
+        public void Constructor_StillThrowsOnUnredactedHashtableRendering()
+        {
+            // The "real miss" case the guard is meant to catch: a hashtable rendering that contains
+            // an unredacted client_secret key. Not in the allowlist (different shape — no surrounding
+            // quotes wrapping just the enum string). Must still throw.
+            Assert.ThrowsException<InvalidOperationException>(() =>
+                new DriftField(
+                    "options",
+                    DriftChangeType.Modified,
+                    null,
+                    "{client_secret: redacted, something: else}"));
+        }
+
+        [TestMethod]
+        public void Constructor_StillThrowsOnUserStringContainingMarker()
+        {
+            // A user-controlled string field (e.g. description) whose value happens to contain the
+            // literal marker as a substring must still throw — we'd rather fail loud on a
+            // misclassified user-string than under-redact. The allowlist matches exact quoted
+            // values only, so an embedded marker inside a longer quoted string trips the guard.
+            Assert.ThrowsException<InvalidOperationException>(() =>
+                new DriftField(
+                    "description",
+                    DriftChangeType.Added,
+                    null,
+                    "\"users.client_secret_post is bad\""));
+        }
+    }
+}

--- a/src/Alethic.Auth0.Operator.Tests/Controllers/LogValueFormatterTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Controllers/LogValueFormatterTests.cs
@@ -50,6 +50,11 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
         [DataRow("signing_key")]
         [DataRow("certificate")]
         [DataRow("pfx")]
+        // H1 / MR !3 rufus review — pfx must match as a complete _/.- bounded segment, covering
+        // leading, middle, trailing, and whole-key positions.
+        [DataRow("cert.pfx")]
+        [DataRow("pfx_data")]
+        [DataRow("oauth.pfx_blob")]
         public void IsSensitiveKey_RedactsSecretShapedKey(string key)
         {
             Assert.IsTrue(LogValueFormatter.IsSensitiveKey(key),
@@ -60,6 +65,10 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
         [DataRow("token_endpoint")]
         [DataRow("token_endpoint_auth_method")]
         [DataRow("access_token_lifetime_in_seconds")]
+        // H1 / MR !3 rufus review — keys whose name merely contains the three letters "pfx" as
+        // a non-boundary substring must NOT redact (they're not pkcs12 blobs).
+        [DataRow("prefix_url")]
+        [DataRow("spfx_config")]
         public void IsSensitiveKey_DoesNotRedactNonSecretTokenNamedKey(string key)
         {
             Assert.IsFalse(LogValueFormatter.IsSensitiveKey(key),

--- a/src/Alethic.Auth0.Operator.Tests/Controllers/V1ConnectionControllerWriteLogTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Controllers/V1ConnectionControllerWriteLogTests.cs
@@ -1,83 +1,123 @@
-using System.IO;
+using System;
 using System.Linq;
-using System.Text.RegularExpressions;
+using System.Reflection;
+using System.Text.Json;
 
+using Alethic.Auth0.Operator.Controllers;
+using Alethic.Auth0.Operator.Models;
+using Alethic.Auth0.Operator.Options;
+using Alethic.Auth0.Operator.Tests.TestSupport;
+
+using KubeOps.Abstractions.Queue;
+using KubeOps.KubernetesClient;
+
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Moq;
 
 namespace Alethic.Auth0.Operator.Tests.Controllers
 {
     /// <summary>
-    /// Regression guard for F7 / LA-RF-81: the connection-update write path must thread the real
-    /// <c>entity.Namespace()</c> through to the <c>LogAuth0Write</c> call — not the hard-coded
-    /// <c>"unknown"</c> literal that previously caused every Datadog
-    /// <c>auth0ApiCallPurpose:"update_connection"</c> log to render <c>entityNamespace:"unknown"</c>.
+    /// Regression guard for F7 / LA-RF-81: the connection write paths must thread the real
+    /// <c>entity.Namespace()</c> (passed through as <c>defaultNamespace</c>) into the
+    /// <c>LogAuth0Write</c> funnel — not the hard-coded <c>"unknown"</c> literal that
+    /// previously caused every Datadog <c>auth0ApiCallPurpose:"update_connection"</c> /
+    /// <c>"reset_connection_metadata"</c> log line to render <c>entityNamespace:"unknown"</c>.
     /// <para>
-    /// The <c>Update</c> method receives <c>defaultNamespace</c> from
-    /// <see cref="V1TenantEntityController{TEntity,TConf}.PerformUpdate"/>, which passes
-    /// <c>entity.Namespace()</c>. Asserting at the call-site source-text level (rather than via
-    /// SDK mocking) is the lightest-weight guard that survives signature refactors and catches
-    /// future copy-paste regressions of the literal.
+    /// M3 (LA-RF-81 code review) replaced the previous source-text regex with this behavioural
+    /// test. We invoke the protected <c>LogAuth0Write</c> directly via reflection on a real
+    /// <see cref="V1ConnectionController"/> instance — same funnel the production
+    /// <c>update_connection</c> and <c>reset_connection_metadata</c> call sites use — and
+    /// assert the captured JSON payload carries the namespace we passed in.
     /// </para>
     /// </summary>
     [TestClass]
     public class V1ConnectionControllerWriteLogTests
     {
-        private static string ReadConnectionControllerSource()
-        {
-            // The test runs from the test assembly's bin dir; walk up to repo root, then into the
-            // operator project. This keeps the test self-contained and avoids new test-data plumbing.
-            var dir = new DirectoryInfo(System.AppContext.BaseDirectory);
-            while (dir != null && !File.Exists(Path.Combine(dir.FullName, "Alethic.Auth0.Operator.sln")))
-                dir = dir.Parent;
-
-            Assert.IsNotNull(dir, "Could not locate repo root (Alethic.Auth0.Operator.sln) by walking up from test bin dir.");
-
-            var sourcePath = Path.Combine(
-                dir!.FullName,
-                "src", "Alethic.Auth0.Operator", "Controllers", "V1ConnectionController.cs");
-            Assert.IsTrue(File.Exists(sourcePath), $"Expected source file at {sourcePath}.");
-
-            return File.ReadAllText(sourcePath);
-        }
+        [TestMethod]
+        public void LogAuth0Write_PassesEntityNamespaceThroughForUpdateConnection()
+            => AssertLogAuth0WriteRoutesNamespace(purpose: "update_connection", expectedNamespace: "team-alpha");
 
         [TestMethod]
-        public void UpdateConnection_LogAuth0WriteCall_PassesDefaultNamespace_NotLiteralUnknown()
+        public void LogAuth0Write_PassesEntityNamespaceThroughForResetConnectionMetadata()
+            => AssertLogAuth0WriteRoutesNamespace(purpose: "reset_connection_metadata", expectedNamespace: "team-bravo");
+
+        private static void AssertLogAuth0WriteRoutesNamespace(string purpose, string expectedNamespace)
         {
-            var source = ReadConnectionControllerSource();
+            var capturingLogger = new CapturingLogger();
+            var controller = BuildController(capturingLogger);
 
-            // Match the LogAuth0Write call for update_connection. The signature is:
-            //   LogAuth0Write(message, entityType, entityName, entityNamespace, purpose, driftContext)
-            // We assert the 4th positional argument (entityNamespace) is `defaultNamespace`, and
-            // the 5th is the literal "update_connection".
-            var pattern = new Regex(
-                @"LogAuth0Write\([^,]+,\s*""A0Connection""\s*,\s*[^,]+,\s*(?<ns>[^,]+),\s*""update_connection""",
-                RegexOptions.Singleline);
+            // LogAuth0Write is protected on V1Controller<TEntity,TSpec,TStatus,TConf>.
+            // Reflect onto its closed-generic base to invoke it on the V1ConnectionController
+            // instance — exactly the same funnel the production update path uses.
+            var method = FindLogAuth0Write(controller.GetType());
+            Assert.IsNotNull(method, "LogAuth0Write(message, entityType, entityName, entityNamespace, purpose, driftContext) not found on V1ConnectionController.");
 
-            var matches = pattern.Matches(source).Cast<Match>().ToList();
-            Assert.AreEqual(1, matches.Count, "Expected exactly one LogAuth0Write call for update_connection.");
+            var driftContext = DriftLogContext.FirstReconciliation();
+            method!.Invoke(controller, new object?[]
+            {
+                "Updating Auth0 connection with ID: cn_test",
+                "A0Connection",
+                "test-connection",
+                expectedNamespace,
+                purpose,
+                driftContext,
+            });
 
-            var ns = matches[0].Groups["ns"].Value.Trim();
-            Assert.AreEqual("defaultNamespace", ns,
-                $"LogAuth0Write for update_connection must pass defaultNamespace, got '{ns}'. " +
-                "The hard-coded \"unknown\" literal caused entityNamespace to render as \"unknown\" on every " +
-                "Datadog auth0ApiCallPurpose:\"update_connection\" log line.");
+            var jsonEntry = capturingLogger.Entries
+                .Where(e => e.Level == LogLevel.Warning) // LogAuth0Write emits at Warning
+                .Select(e => TryParseJson(e.Message))
+                .FirstOrDefault(d => d is not null
+                                     && d.RootElement.TryGetProperty("auth0ApiCallPurpose", out var p)
+                                     && p.GetString() == purpose);
+
+            Assert.IsNotNull(jsonEntry, $"Expected a structured Warning log carrying auth0ApiCallPurpose={purpose}.");
+
+            var root = jsonEntry!.RootElement;
+            Assert.IsTrue(root.TryGetProperty("entityNamespace", out var nsProp),
+                $"LogAuth0Write payload for purpose={purpose} must include `entityNamespace`.");
+            Assert.AreEqual(expectedNamespace, nsProp.GetString(),
+                $"LogAuth0Write for purpose={purpose} must thread `defaultNamespace` through to `entityNamespace`. " +
+                $"Got '{nsProp.GetString()}', expected '{expectedNamespace}'. " +
+                "The hard-coded \"unknown\" literal previously caused entityNamespace to render as \"unknown\" " +
+                "on every Datadog log line for these purposes.");
+            Assert.AreEqual("A0Connection", root.GetProperty("entityTypeName").GetString());
         }
 
-        [TestMethod]
-        public void ResetConnectionMetadata_LogAuth0WriteCall_PassesDefaultNamespace_NotLiteralUnknown()
+        private static MethodInfo? FindLogAuth0Write(Type startType)
         {
-            var source = ReadConnectionControllerSource();
+            for (var t = startType; t != null; t = t.BaseType)
+            {
+                var method = t.GetMethod(
+                    "LogAuth0Write",
+                    BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+                if (method is not null)
+                    return method;
+            }
+            return null;
+        }
 
-            var pattern = new Regex(
-                @"LogAuth0Write\([^,]+,\s*""A0Connection""\s*,\s*[^,]+,\s*(?<ns>[^,]+),\s*""reset_connection_metadata""",
-                RegexOptions.Singleline);
+        private static V1ConnectionController BuildController(ILogger logger)
+        {
+            var kube = new Mock<IKubernetesClient>(MockBehavior.Loose).Object;
+            EntityRequeue<V1Connection> requeue = (_, __) => { };
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var options = Microsoft.Extensions.Options.Options.Create(new OperatorOptions());
+            return new V1ConnectionController(
+                kube,
+                requeue,
+                cache,
+                new TypedLoggerAdapter<V1ConnectionController>(logger),
+                options);
+        }
 
-            var matches = pattern.Matches(source).Cast<Match>().ToList();
-            Assert.AreEqual(1, matches.Count, "Expected exactly one LogAuth0Write call for reset_connection_metadata.");
-
-            var ns = matches[0].Groups["ns"].Value.Trim();
-            Assert.AreEqual("defaultNamespace", ns,
-                $"LogAuth0Write for reset_connection_metadata must pass defaultNamespace, got '{ns}'.");
+        private static JsonDocument? TryParseJson(string message)
+        {
+            try { return JsonDocument.Parse(message); }
+            catch { return null; }
         }
     }
 }

--- a/src/Alethic.Auth0.Operator.Tests/Controllers/V1ConnectionControllerWriteLogTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Controllers/V1ConnectionControllerWriteLogTests.cs
@@ -1,0 +1,83 @@
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Alethic.Auth0.Operator.Tests.Controllers
+{
+    /// <summary>
+    /// Regression guard for F7 / LA-RF-81: the connection-update write path must thread the real
+    /// <c>entity.Namespace()</c> through to the <c>LogAuth0Write</c> call — not the hard-coded
+    /// <c>"unknown"</c> literal that previously caused every Datadog
+    /// <c>auth0ApiCallPurpose:"update_connection"</c> log to render <c>entityNamespace:"unknown"</c>.
+    /// <para>
+    /// The <c>Update</c> method receives <c>defaultNamespace</c> from
+    /// <see cref="V1TenantEntityController{TEntity,TConf}.PerformUpdate"/>, which passes
+    /// <c>entity.Namespace()</c>. Asserting at the call-site source-text level (rather than via
+    /// SDK mocking) is the lightest-weight guard that survives signature refactors and catches
+    /// future copy-paste regressions of the literal.
+    /// </para>
+    /// </summary>
+    [TestClass]
+    public class V1ConnectionControllerWriteLogTests
+    {
+        private static string ReadConnectionControllerSource()
+        {
+            // The test runs from the test assembly's bin dir; walk up to repo root, then into the
+            // operator project. This keeps the test self-contained and avoids new test-data plumbing.
+            var dir = new DirectoryInfo(System.AppContext.BaseDirectory);
+            while (dir != null && !File.Exists(Path.Combine(dir.FullName, "Alethic.Auth0.Operator.sln")))
+                dir = dir.Parent;
+
+            Assert.IsNotNull(dir, "Could not locate repo root (Alethic.Auth0.Operator.sln) by walking up from test bin dir.");
+
+            var sourcePath = Path.Combine(
+                dir!.FullName,
+                "src", "Alethic.Auth0.Operator", "Controllers", "V1ConnectionController.cs");
+            Assert.IsTrue(File.Exists(sourcePath), $"Expected source file at {sourcePath}.");
+
+            return File.ReadAllText(sourcePath);
+        }
+
+        [TestMethod]
+        public void UpdateConnection_LogAuth0WriteCall_PassesDefaultNamespace_NotLiteralUnknown()
+        {
+            var source = ReadConnectionControllerSource();
+
+            // Match the LogAuth0Write call for update_connection. The signature is:
+            //   LogAuth0Write(message, entityType, entityName, entityNamespace, purpose, driftContext)
+            // We assert the 4th positional argument (entityNamespace) is `defaultNamespace`, and
+            // the 5th is the literal "update_connection".
+            var pattern = new Regex(
+                @"LogAuth0Write\([^,]+,\s*""A0Connection""\s*,\s*[^,]+,\s*(?<ns>[^,]+),\s*""update_connection""",
+                RegexOptions.Singleline);
+
+            var matches = pattern.Matches(source).Cast<Match>().ToList();
+            Assert.AreEqual(1, matches.Count, "Expected exactly one LogAuth0Write call for update_connection.");
+
+            var ns = matches[0].Groups["ns"].Value.Trim();
+            Assert.AreEqual("defaultNamespace", ns,
+                $"LogAuth0Write for update_connection must pass defaultNamespace, got '{ns}'. " +
+                "The hard-coded \"unknown\" literal caused entityNamespace to render as \"unknown\" on every " +
+                "Datadog auth0ApiCallPurpose:\"update_connection\" log line.");
+        }
+
+        [TestMethod]
+        public void ResetConnectionMetadata_LogAuth0WriteCall_PassesDefaultNamespace_NotLiteralUnknown()
+        {
+            var source = ReadConnectionControllerSource();
+
+            var pattern = new Regex(
+                @"LogAuth0Write\([^,]+,\s*""A0Connection""\s*,\s*[^,]+,\s*(?<ns>[^,]+),\s*""reset_connection_metadata""",
+                RegexOptions.Singleline);
+
+            var matches = pattern.Matches(source).Cast<Match>().ToList();
+            Assert.AreEqual(1, matches.Count, "Expected exactly one LogAuth0Write call for reset_connection_metadata.");
+
+            var ns = matches[0].Groups["ns"].Value.Trim();
+            Assert.AreEqual("defaultNamespace", ns,
+                $"LogAuth0Write for reset_connection_metadata must pass defaultNamespace, got '{ns}'.");
+        }
+    }
+}

--- a/src/Alethic.Auth0.Operator.Tests/Controllers/V1ControllerRateLimitObservabilityTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Controllers/V1ControllerRateLimitObservabilityTests.cs
@@ -11,6 +11,7 @@ using Alethic.Auth0.Operator.Controllers;
 using Alethic.Auth0.Operator.Core.Models.Client;
 using Alethic.Auth0.Operator.Models;
 using Alethic.Auth0.Operator.Options;
+using Alethic.Auth0.Operator.Tests.TestSupport;
 
 using Auth0.Core;
 using Auth0.Core.Exceptions;
@@ -82,56 +83,52 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
         public async Task RateLimitApiException_RequeueDelay_AppliesJitterWithinTwentyPercentOfResetHint()
         {
             // Reset is 100s in the future → base delay ~100s (well above the 60s floor).
-            // With the jitter sampler driven to its endpoints, the requeue delay must
-            // land inside [80s, 120s] (i.e. 100s ± 20%).
-            var originalSampler = V1Controller<V1Client, V1Client.SpecDef, V1Client.StatusDef, ClientConf>.RateLimitJitterSampler;
-            try
+            // Jitter is now one-sided [1.0, 1.2) — never below the floored reset hint —
+            // so with the jitter sampler driven to its endpoints, the requeue delay must
+            // land inside [100s, 120s].
+            // The baseDelay is computed inside ReconcileAsync from (Reset - Now), so a
+            // small clock drift between exception construction and catch-handling shaves
+            // up to ~2s off the floored 100s base. Assertions tolerate that drift while
+            // still enforcing the [1.0, 1.2) jitter shape.
+            foreach (var (sample, expectMin, expectMax) in new[]
             {
-                foreach (var (sample, expectMin, expectMax) in new[]
-                {
-                    (0.0,   80.0,  80.0),    // factor = 0.8 → 100 * 0.8 = 80s exact
-                    (0.5,   99.99, 100.01),  // factor = 1.0 → 100s exact
-                    (0.999, 119.0, 120.0),   // factor ≈ 1.2 → ~120s
-                })
-                {
-                    V1Controller<V1Client, V1Client.SpecDef, V1Client.StatusDef, ClientConf>.RateLimitJitterSampler = () => sample;
-
-                    var entity = MakeClient();
-                    var requeueCalls = new List<(V1Client entity, TimeSpan delay)>();
-                    var kube = new Mock<IKubernetesClient>(MockBehavior.Loose);
-                    var controller = new TestController(
-                        kube.Object,
-                        requeue: (e, d) => requeueCalls.Add((e, d)),
-                        reconcileImpl: (_, __) => throw MakeRateLimitExceptionAt(DateTimeOffset.Now.AddSeconds(100)));
-
-                    await controller.ReconcileAsync(entity, CancellationToken.None);
-
-                    Assert.AreEqual(1, requeueCalls.Count, $"sample={sample}: expected exactly one Requeue.");
-                    var d = requeueCalls[0].delay.TotalSeconds;
-                    Assert.IsTrue(d >= expectMin - 1 && d <= expectMax + 1,
-                        $"sample={sample}: expected delay in [{expectMin}s, {expectMax}s]; got {d:F2}s.");
-                }
-
-                // Floor-clamp: a Reset that is in the past (or very near) must clamp
-                // to the 60s floor even when jitter would push lower. With sample=0.0
-                // the jitter factor is 0.8 → 60s * 0.8 = 48s pre-clamp → clamp to 60s.
-                V1Controller<V1Client, V1Client.SpecDef, V1Client.StatusDef, ClientConf>.RateLimitJitterSampler = () => 0.0;
-                var entity2 = MakeClient();
-                var requeueCalls2 = new List<(V1Client entity, TimeSpan delay)>();
-                var kube2 = new Mock<IKubernetesClient>(MockBehavior.Loose);
-                var controller2 = new TestController(
-                    kube2.Object,
-                    requeue: (e, d) => requeueCalls2.Add((e, d)),
-                    reconcileImpl: (_, __) => throw MakeRateLimitExceptionAt(DateTimeOffset.Now.AddSeconds(-30)));
-                await controller2.ReconcileAsync(entity2, CancellationToken.None);
-                Assert.AreEqual(1, requeueCalls2.Count);
-                Assert.AreEqual(TimeSpan.FromMinutes(1), requeueCalls2[0].delay,
-                    "Past/near-zero Reset must clamp to the 60s floor regardless of jitter.");
-            }
-            finally
+                (0.0,   98.0,  100.0),   // factor = 1.0 → ~100s (minus clock drift)
+                (0.5,   107.0, 110.0),   // factor = 1.1 → ~110s
+                (0.999, 117.0, 120.0),   // factor ≈ 1.2 → ~120s
+            })
             {
-                V1Controller<V1Client, V1Client.SpecDef, V1Client.StatusDef, ClientConf>.RateLimitJitterSampler = originalSampler;
+                var entity = MakeClient();
+                var requeueCalls = new List<(V1Client entity, TimeSpan delay)>();
+                var kube = new Mock<IKubernetesClient>(MockBehavior.Loose);
+                var controller = new TestController(
+                    kube.Object,
+                    requeue: (e, d) => requeueCalls.Add((e, d)),
+                    reconcileImpl: (_, __) => throw MakeRateLimitExceptionAt(DateTimeOffset.Now.AddSeconds(100)),
+                    jitterSample: sample);
+
+                await controller.ReconcileAsync(entity, CancellationToken.None);
+
+                Assert.AreEqual(1, requeueCalls.Count, $"sample={sample}: expected exactly one Requeue.");
+                var d = requeueCalls[0].delay.TotalSeconds;
+                Assert.IsTrue(d >= expectMin && d <= expectMax,
+                    $"sample={sample}: expected delay in [{expectMin}s, {expectMax}s]; got {d:F2}s.");
             }
+
+            // Floor-clamp: a Reset that is in the past (or very near) must clamp to the
+            // 60s floor. With one-sided jitter the floored 60s only spreads upward
+            // (60s → [60s, 72s]); driving the sample to 0.0 yields exactly 60s.
+            var entity2 = MakeClient();
+            var requeueCalls2 = new List<(V1Client entity, TimeSpan delay)>();
+            var kube2 = new Mock<IKubernetesClient>(MockBehavior.Loose);
+            var controller2 = new TestController(
+                kube2.Object,
+                requeue: (e, d) => requeueCalls2.Add((e, d)),
+                reconcileImpl: (_, __) => throw MakeRateLimitExceptionAt(DateTimeOffset.Now.AddSeconds(-30)),
+                jitterSample: 0.0);
+            await controller2.ReconcileAsync(entity2, CancellationToken.None);
+            Assert.AreEqual(1, requeueCalls2.Count);
+            Assert.AreEqual(TimeSpan.FromMinutes(1), requeueCalls2[0].delay,
+                "Past/near-zero Reset must clamp to the 60s floor with sample=0.0 (factor=1.0).");
         }
 
         // ============================================================================
@@ -177,12 +174,64 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
             Assert.AreEqual(resetAt.ToUnixTimeSeconds(), parsed.ToUnixTimeSeconds(),
                 "`auth0RateLimitResetUtc` must round-trip to the same instant as RateLimit.Reset.");
 
+            Assert.IsTrue(root.TryGetProperty("auth0RequeueFloorSeconds", out var floorProp),
+                "Expected `auth0RequeueFloorSeconds` field (pre-jitter floor) on the warn log.");
+            Assert.AreEqual(JsonValueKind.Number, floorProp.ValueKind);
+            var requeueFloor = floorProp.GetInt32();
+            Assert.IsTrue(requeueFloor >= 60,
+                $"`auth0RequeueFloorSeconds` must be at least the 60s floor; got {requeueFloor}.");
+
             Assert.IsTrue(root.TryGetProperty("auth0RequeueAfterSeconds", out var requeueProp),
-                "Expected `auth0RequeueAfterSeconds` field on the warn log.");
+                "Expected `auth0RequeueAfterSeconds` field (post-jitter actual delay) on the warn log.");
             Assert.AreEqual(JsonValueKind.Number, requeueProp.ValueKind);
             var requeueAfter = requeueProp.GetInt32();
-            Assert.IsTrue(requeueAfter >= 60,
-                $"`auth0RequeueAfterSeconds` must be at least the 60s floor; got {requeueAfter}.");
+            Assert.IsTrue(requeueAfter >= requeueFloor,
+                $"`auth0RequeueAfterSeconds` ({requeueAfter}) must be >= floor ({requeueFloor}) — jitter is one-sided upward.");
+            Assert.IsTrue(requeueAfter <= (int)Math.Ceiling(requeueFloor * 1.2),
+                $"`auth0RequeueAfterSeconds` ({requeueAfter}) must be <= floor*1.2 ({requeueFloor * 1.2}).");
+        }
+
+        // ============================================================================
+        // 2b. RateLimit warn log: auth0RequeueAfterSeconds carries the POST-jitter value
+        //     used by Requeue(...), not the pre-jitter floor.
+        // ============================================================================
+
+        [TestMethod]
+        public async Task RateLimitApiException_RequeueDelay_LogReportsPostJitterValue()
+        {
+            // Reset 150s in the future, jitter sample = 0.999 → factor ≈ 1.1998 → ~180s
+            // (well above the 150s floor). The log's auth0RequeueAfterSeconds must reflect
+            // the post-jitter value (~180s), not the pre-jitter floor (150s).
+            var resetAt = DateTimeOffset.UtcNow.AddSeconds(150);
+            var entity = MakeClient();
+            var capturingLogger = new CapturingLogger();
+            var kube = new Mock<IKubernetesClient>(MockBehavior.Loose);
+            var controller = new TestController(
+                kube.Object,
+                requeue: (_, __) => { },
+                logger: capturingLogger,
+                reconcileImpl: (_, __) => throw MakeRateLimitExceptionAt(resetAt),
+                jitterSample: 0.999);
+
+            await controller.ReconcileAsync(entity, CancellationToken.None);
+
+            var rateLimitEntry = capturingLogger.Entries
+                .Where(e => e.Level == LogLevel.Warning)
+                .Select(e => TryParseJson(e.Message))
+                .Where(e => e is not null)
+                .FirstOrDefault(e => e!.RootElement.TryGetProperty("message", out var m)
+                                     && m.GetString()!.Contains("Auth0 rate limit exceeded"));
+            Assert.IsNotNull(rateLimitEntry);
+
+            var root = rateLimitEntry!.RootElement;
+            var floor = root.GetProperty("auth0RequeueFloorSeconds").GetInt32();
+            var after = root.GetProperty("auth0RequeueAfterSeconds").GetInt32();
+
+            // floor should be ~150s (give or take 1s for the clock); after should be ~floor*1.2.
+            Assert.IsTrue(floor >= 149 && floor <= 150, $"floor={floor}, expected ~150s.");
+            var expectedAfter = floor * 1.2;
+            Assert.IsTrue(Math.Abs(after - expectedAfter) <= 1,
+                $"auth0RequeueAfterSeconds ({after}) must equal floor*1.2 (~{expectedAfter:F1}) ±1s.");
         }
 
         // ============================================================================
@@ -256,49 +305,20 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
         }
 
         // ---- Test scaffolding ----
-
-        private sealed class CapturingLogEntry
-        {
-            public LogLevel Level { get; init; }
-            public string Message { get; init; } = string.Empty;
-            public Exception? Exception { get; init; }
-        }
-
-        /// <summary>
-        /// Minimal capturing logger. Records the formatted message (which, for the
-        /// structured-JSON helpers under test, is the raw JSON payload).
-        /// </summary>
-        private sealed class CapturingLogger : ILogger
-        {
-            public List<CapturingLogEntry> Entries { get; } = new();
-            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
-            public bool IsEnabled(LogLevel logLevel) => true;
-            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
-            {
-                Entries.Add(new CapturingLogEntry
-                {
-                    Level = logLevel,
-                    Message = formatter(state, exception),
-                    Exception = exception,
-                });
-            }
-
-            private sealed class NullScope : IDisposable
-            {
-                public static readonly NullScope Instance = new();
-                public void Dispose() { }
-            }
-        }
+        // CapturingLogger / CapturingLogEntry / TypedLoggerAdapter live in
+        // Alethic.Auth0.Operator.Tests.TestSupport (lifted in M3 / LA-RF-81 review).
 
         private sealed class TestController : V1TenantEntityController<V1Client, V1Client.SpecDef, V1Client.StatusDef, ClientConf>
         {
             private readonly Func<TestController, V1Client, Task>? _reconcileImpl;
+            private readonly double? _jitterSample;
 
             public TestController(
                 IKubernetesClient kube,
                 EntityRequeue<V1Client> requeue,
                 Func<TestController, V1Client, Task>? reconcileImpl = null,
-                ILogger? logger = null)
+                ILogger? logger = null,
+                double? jitterSample = null)
                 : base(
                     kube,
                     requeue,
@@ -309,9 +329,15 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
                     global::Microsoft.Extensions.Options.Options.Create(new OperatorOptions()))
             {
                 _reconcileImpl = reconcileImpl;
+                _jitterSample = jitterSample;
             }
 
             protected override string EntityTypeName => "A0Client";
+
+            // F4 (LA-RF-81): override the protected virtual jitter seam to drive jitter
+            // deterministically when the test supplies a fixed sample.
+            protected override double SampleRateLimitJitter()
+                => _jitterSample ?? base.SampleRateLimitJitter();
 
             protected override Task<System.Collections.Hashtable?> Get(global::Auth0.ManagementApi.IManagementApiClient api, string id, string defaultNamespace, CancellationToken cancellationToken)
                 => Task.FromResult<System.Collections.Hashtable?>(null);
@@ -336,21 +362,6 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
                     await _reconcileImpl(this, entity);
                 return (false, entity);
             }
-        }
-
-        /// <summary>
-        /// Adapts a non-generic <see cref="ILogger"/> instance into the
-        /// <see cref="ILogger{T}"/> the base constructor demands, so tests can supply
-        /// a single capturing logger.
-        /// </summary>
-        private sealed class TypedLoggerAdapter<T> : ILogger<T>
-        {
-            private readonly ILogger _inner;
-            public TypedLoggerAdapter(ILogger inner) { _inner = inner; }
-            public IDisposable BeginScope<TState>(TState state) where TState : notnull => _inner.BeginScope(state)!;
-            public bool IsEnabled(LogLevel logLevel) => _inner.IsEnabled(logLevel);
-            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
-                => _inner.Log(logLevel, eventId, state, exception, formatter);
         }
     }
 }

--- a/src/Alethic.Auth0.Operator.Tests/Controllers/V1ControllerRateLimitObservabilityTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Controllers/V1ControllerRateLimitObservabilityTests.cs
@@ -1,0 +1,356 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Alethic.Auth0.Operator.Controllers;
+using Alethic.Auth0.Operator.Core.Models.Client;
+using Alethic.Auth0.Operator.Models;
+using Alethic.Auth0.Operator.Options;
+
+using Auth0.Core;
+using Auth0.Core.Exceptions;
+
+using k8s.Models;
+
+using KubeOps.Abstractions.Queue;
+using KubeOps.KubernetesClient;
+
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Moq;
+
+namespace Alethic.Auth0.Operator.Tests.Controllers
+{
+    /// <summary>
+    /// Coverage for the F4 (LA-RF-81) log-routing + jitter changes in
+    /// <c>V1Controller.ReconcileAsync</c>'s <see cref="RateLimitApiException"/> and
+    /// <see cref="ErrorApiException"/> catches. See:
+    /// <list type="bullet">
+    /// <item>plans/2026-05-19__18-12-45 - auth0-operator - resolve-drifts-and-error-noise.md</item>
+    /// <item>Architect decision — 2026-05-19 (Option C, log-routing + jitter only, no Polly).</item>
+    /// </list>
+    /// </summary>
+    [TestClass]
+    public class V1ControllerRateLimitObservabilityTests
+    {
+        // ---- Common helpers ----
+
+        private static V1Client MakeClient(string name = "c1", string ns = "default", string? resourceVersion = "rv-1")
+        {
+            return new V1Client
+            {
+                Metadata = new V1ObjectMeta
+                {
+                    Name = name,
+                    NamespaceProperty = ns,
+                    ResourceVersion = resourceVersion,
+                    Annotations = new Dictionary<string, string>(),
+                },
+                Spec = new V1Client.SpecDef { Conf = new ClientConf() },
+                Status = new V1Client.StatusDef(),
+            };
+        }
+
+        private static RateLimitApiException MakeRateLimitExceptionAt(DateTimeOffset resetAt)
+        {
+            // The SDK's RateLimit type is parsed from HTTP headers; the simplest way to
+            // get an instance pointing at a specific Reset is to round-trip through
+            // RateLimit.Parse on a synthetic response.
+            using var resp = new HttpResponseMessage((HttpStatusCode)429);
+            resp.Headers.TryAddWithoutValidation("X-RateLimit-Reset", resetAt.ToUnixTimeSeconds().ToString());
+            resp.Headers.TryAddWithoutValidation("X-RateLimit-Limit", "100");
+            resp.Headers.TryAddWithoutValidation("X-RateLimit-Remaining", "0");
+            var rl = RateLimit.Parse(resp.Headers);
+            return new RateLimitApiException(rl, new ApiError { Message = "Too Many Requests" });
+        }
+
+        // ============================================================================
+        // 1. Jitter window — assert requeue delay falls within ±20% of (Reset - Now),
+        //    floored at 60s. Drives the sampler at its extreme endpoints to verify
+        //    the [-20%, +20%) range and the floor-clamp.
+        // ============================================================================
+
+        [TestMethod]
+        public async Task RateLimitApiException_RequeueDelay_AppliesJitterWithinTwentyPercentOfResetHint()
+        {
+            // Reset is 100s in the future → base delay ~100s (well above the 60s floor).
+            // With the jitter sampler driven to its endpoints, the requeue delay must
+            // land inside [80s, 120s] (i.e. 100s ± 20%).
+            var originalSampler = V1Controller<V1Client, V1Client.SpecDef, V1Client.StatusDef, ClientConf>.RateLimitJitterSampler;
+            try
+            {
+                foreach (var (sample, expectMin, expectMax) in new[]
+                {
+                    (0.0,   80.0,  80.0),    // factor = 0.8 → 100 * 0.8 = 80s exact
+                    (0.5,   99.99, 100.01),  // factor = 1.0 → 100s exact
+                    (0.999, 119.0, 120.0),   // factor ≈ 1.2 → ~120s
+                })
+                {
+                    V1Controller<V1Client, V1Client.SpecDef, V1Client.StatusDef, ClientConf>.RateLimitJitterSampler = () => sample;
+
+                    var entity = MakeClient();
+                    var requeueCalls = new List<(V1Client entity, TimeSpan delay)>();
+                    var kube = new Mock<IKubernetesClient>(MockBehavior.Loose);
+                    var controller = new TestController(
+                        kube.Object,
+                        requeue: (e, d) => requeueCalls.Add((e, d)),
+                        reconcileImpl: (_, __) => throw MakeRateLimitExceptionAt(DateTimeOffset.Now.AddSeconds(100)));
+
+                    await controller.ReconcileAsync(entity, CancellationToken.None);
+
+                    Assert.AreEqual(1, requeueCalls.Count, $"sample={sample}: expected exactly one Requeue.");
+                    var d = requeueCalls[0].delay.TotalSeconds;
+                    Assert.IsTrue(d >= expectMin - 1 && d <= expectMax + 1,
+                        $"sample={sample}: expected delay in [{expectMin}s, {expectMax}s]; got {d:F2}s.");
+                }
+
+                // Floor-clamp: a Reset that is in the past (or very near) must clamp
+                // to the 60s floor even when jitter would push lower. With sample=0.0
+                // the jitter factor is 0.8 → 60s * 0.8 = 48s pre-clamp → clamp to 60s.
+                V1Controller<V1Client, V1Client.SpecDef, V1Client.StatusDef, ClientConf>.RateLimitJitterSampler = () => 0.0;
+                var entity2 = MakeClient();
+                var requeueCalls2 = new List<(V1Client entity, TimeSpan delay)>();
+                var kube2 = new Mock<IKubernetesClient>(MockBehavior.Loose);
+                var controller2 = new TestController(
+                    kube2.Object,
+                    requeue: (e, d) => requeueCalls2.Add((e, d)),
+                    reconcileImpl: (_, __) => throw MakeRateLimitExceptionAt(DateTimeOffset.Now.AddSeconds(-30)));
+                await controller2.ReconcileAsync(entity2, CancellationToken.None);
+                Assert.AreEqual(1, requeueCalls2.Count);
+                Assert.AreEqual(TimeSpan.FromMinutes(1), requeueCalls2[0].delay,
+                    "Past/near-zero Reset must clamp to the 60s floor regardless of jitter.");
+            }
+            finally
+            {
+                V1Controller<V1Client, V1Client.SpecDef, V1Client.StatusDef, ClientConf>.RateLimitJitterSampler = originalSampler;
+            }
+        }
+
+        // ============================================================================
+        // 2. RateLimit warn log carries the new facet fields.
+        // ============================================================================
+
+        [TestMethod]
+        public async Task RateLimitApiException_LogIncludesResetAndRequeueFields()
+        {
+            var resetAt = DateTimeOffset.UtcNow.AddSeconds(150);
+
+            var entity = MakeClient();
+            var capturingLogger = new CapturingLogger();
+            var kube = new Mock<IKubernetesClient>(MockBehavior.Loose);
+            var controller = new TestController(
+                kube.Object,
+                requeue: (_, __) => { },
+                logger: capturingLogger,
+                reconcileImpl: (_, __) => throw MakeRateLimitExceptionAt(resetAt));
+
+            await controller.ReconcileAsync(entity, CancellationToken.None);
+
+            // The first Warning log emitted from the RateLimit catch is the "Auth0 rate
+            // limit exceeded ..." structured payload. Parse it and assert facet fields.
+            var warnEntries = capturingLogger.Entries
+                .Where(e => e.Level == LogLevel.Warning)
+                .Select(e => TryParseJson(e.Message))
+                .Where(e => e is not null)
+                .ToList();
+
+            var rateLimitEntry = warnEntries
+                .FirstOrDefault(e => e!.RootElement.TryGetProperty("message", out var m)
+                                     && m.GetString()!.Contains("Auth0 rate limit exceeded"));
+            Assert.IsNotNull(rateLimitEntry, "Expected the structured Auth0-rate-limit-exceeded warn log to be emitted.");
+
+            var root = rateLimitEntry!.RootElement;
+            Assert.IsTrue(root.TryGetProperty("auth0RateLimitResetUtc", out var resetProp),
+                "Expected `auth0RateLimitResetUtc` field on the warn log.");
+            Assert.IsFalse(resetProp.ValueKind == JsonValueKind.Null,
+                "`auth0RateLimitResetUtc` must be non-null when RateLimit.Reset is present.");
+            // ISO-8601 round-trip
+            var parsed = DateTimeOffset.Parse(resetProp.GetString()!);
+            Assert.AreEqual(resetAt.ToUnixTimeSeconds(), parsed.ToUnixTimeSeconds(),
+                "`auth0RateLimitResetUtc` must round-trip to the same instant as RateLimit.Reset.");
+
+            Assert.IsTrue(root.TryGetProperty("auth0RequeueAfterSeconds", out var requeueProp),
+                "Expected `auth0RequeueAfterSeconds` field on the warn log.");
+            Assert.AreEqual(JsonValueKind.Number, requeueProp.ValueKind);
+            var requeueAfter = requeueProp.GetInt32();
+            Assert.IsTrue(requeueAfter >= 60,
+                $"`auth0RequeueAfterSeconds` must be at least the 60s floor; got {requeueAfter}.");
+        }
+
+        // ============================================================================
+        // 3. ErrorApiException 429: retryable hint = true.
+        // ============================================================================
+
+        [TestMethod]
+        public async Task ErrorApiException_429_LogIncludesRetryableHintTrue()
+        {
+            var (root, statusCode, hint) = await CaptureErrorApiLogAsync(HttpStatusCode.TooManyRequests);
+            Assert.AreEqual(429, statusCode);
+            Assert.IsTrue(hint, "`auth0RetryableHint` must be true for HTTP 429.");
+        }
+
+        // ============================================================================
+        // 4. ErrorApiException 400: retryable hint = false.
+        // ============================================================================
+
+        [TestMethod]
+        public async Task ErrorApiException_400_LogIncludesRetryableHintFalse()
+        {
+            var (root, statusCode, hint) = await CaptureErrorApiLogAsync(HttpStatusCode.BadRequest);
+            Assert.AreEqual(400, statusCode);
+            Assert.IsFalse(hint, "`auth0RetryableHint` must be false for HTTP 400.");
+        }
+
+        private static async Task<(JsonElement Root, int StatusCode, bool RetryableHint)> CaptureErrorApiLogAsync(HttpStatusCode status)
+        {
+            var entity = MakeClient();
+            var capturingLogger = new CapturingLogger();
+            var kube = new Mock<IKubernetesClient>(MockBehavior.Loose);
+            var controller = new TestController(
+                kube.Object,
+                requeue: (_, __) => { },
+                logger: capturingLogger,
+                reconcileImpl: (_, __) => throw new ErrorApiException(status, new ApiError { Message = "simulated" }));
+
+            await controller.ReconcileAsync(entity, CancellationToken.None);
+
+            var errorEntry = capturingLogger.Entries
+                .Where(e => e.Level == LogLevel.Error)
+                .Select(e => TryParseJson(e.Message))
+                .Where(e => e is not null)
+                .FirstOrDefault(e => e!.RootElement.TryGetProperty("message", out var m)
+                                     && m.GetString()!.Contains("Auth0 API error during reconciliation"));
+            Assert.IsNotNull(errorEntry, "Expected the structured Auth0-API-error log on the error catch path.");
+
+            var root = errorEntry!.RootElement;
+            Assert.IsTrue(root.TryGetProperty("auth0StatusCode", out var statusProp),
+                "Expected `auth0StatusCode` field on the error log.");
+            Assert.IsTrue(root.TryGetProperty("auth0RetryableHint", out var hintProp),
+                "Expected `auth0RetryableHint` field on the error log.");
+
+            return (root, statusProp.GetInt32(), hintProp.GetBoolean());
+        }
+
+        private static JsonDocument? TryParseJson(string message)
+        {
+            // LogJson wraps the entry into a JSON-encoded string and emits it via the
+            // "{JsonLog}" template — capturing loggers receive the *formatted* message,
+            // which is the raw JSON. Defensive try/catch keeps un-parseable lines from
+            // tripping the test scaffolding.
+            try
+            {
+                return JsonDocument.Parse(message);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        // ---- Test scaffolding ----
+
+        private sealed class CapturingLogEntry
+        {
+            public LogLevel Level { get; init; }
+            public string Message { get; init; } = string.Empty;
+            public Exception? Exception { get; init; }
+        }
+
+        /// <summary>
+        /// Minimal capturing logger. Records the formatted message (which, for the
+        /// structured-JSON helpers under test, is the raw JSON payload).
+        /// </summary>
+        private sealed class CapturingLogger : ILogger
+        {
+            public List<CapturingLogEntry> Entries { get; } = new();
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                Entries.Add(new CapturingLogEntry
+                {
+                    Level = logLevel,
+                    Message = formatter(state, exception),
+                    Exception = exception,
+                });
+            }
+
+            private sealed class NullScope : IDisposable
+            {
+                public static readonly NullScope Instance = new();
+                public void Dispose() { }
+            }
+        }
+
+        private sealed class TestController : V1TenantEntityController<V1Client, V1Client.SpecDef, V1Client.StatusDef, ClientConf>
+        {
+            private readonly Func<TestController, V1Client, Task>? _reconcileImpl;
+
+            public TestController(
+                IKubernetesClient kube,
+                EntityRequeue<V1Client> requeue,
+                Func<TestController, V1Client, Task>? reconcileImpl = null,
+                ILogger? logger = null)
+                : base(
+                    kube,
+                    requeue,
+                    new MemoryCache(new MemoryCacheOptions()),
+                    (ILogger<TestController>)(logger is null
+                        ? Microsoft.Extensions.Logging.Abstractions.NullLogger<TestController>.Instance
+                        : new TypedLoggerAdapter<TestController>(logger)),
+                    global::Microsoft.Extensions.Options.Options.Create(new OperatorOptions()))
+            {
+                _reconcileImpl = reconcileImpl;
+            }
+
+            protected override string EntityTypeName => "A0Client";
+
+            protected override Task<System.Collections.Hashtable?> Get(global::Auth0.ManagementApi.IManagementApiClient api, string id, string defaultNamespace, CancellationToken cancellationToken)
+                => Task.FromResult<System.Collections.Hashtable?>(null);
+
+            protected override Task<string?> Find(global::Auth0.ManagementApi.IManagementApiClient api, V1Client entity, V1Client.SpecDef spec, string defaultNamespace, CancellationToken cancellationToken)
+                => Task.FromResult<string?>(null);
+
+            protected override string? ValidateCreate(ClientConf conf) => null;
+
+            protected override Task<string> Create(global::Auth0.ManagementApi.IManagementApiClient api, ClientConf conf, string defaultNamespace, CancellationToken cancellationToken)
+                => Task.FromResult(string.Empty);
+
+            protected override Task Update(global::Auth0.ManagementApi.IManagementApiClient api, string id, System.Collections.Hashtable? last, ClientConf conf, IReadOnlyList<Alethic.Auth0.Operator.Controllers.DriftField> driftFields, string defaultNamespace, string entityName, Alethic.Auth0.Operator.Services.ITenantApiAccess tenantApiAccess, Alethic.Auth0.Operator.Controllers.DriftLogContext driftContext, CancellationToken cancellationToken)
+                => Task.CompletedTask;
+
+            protected override Task Delete(global::Auth0.ManagementApi.IManagementApiClient api, string id, CancellationToken cancellationToken)
+                => Task.CompletedTask;
+
+            protected override async Task<(bool needsRequeue, V1Client updatedEntity)> Reconcile(V1Client entity, CancellationToken cancellationToken)
+            {
+                if (_reconcileImpl is not null)
+                    await _reconcileImpl(this, entity);
+                return (false, entity);
+            }
+        }
+
+        /// <summary>
+        /// Adapts a non-generic <see cref="ILogger"/> instance into the
+        /// <see cref="ILogger{T}"/> the base constructor demands, so tests can supply
+        /// a single capturing logger.
+        /// </summary>
+        private sealed class TypedLoggerAdapter<T> : ILogger<T>
+        {
+            private readonly ILogger _inner;
+            public TypedLoggerAdapter(ILogger inner) { _inner = inner; }
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => _inner.BeginScope(state)!;
+            public bool IsEnabled(LogLevel logLevel) => _inner.IsEnabled(logLevel);
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+                => _inner.Log(logLevel, eventId, state, exception, formatter);
+        }
+    }
+}

--- a/src/Alethic.Auth0.Operator.Tests/Controllers/V1TenantControllerTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Controllers/V1TenantControllerTests.cs
@@ -107,6 +107,44 @@ namespace Alethic.Auth0.Operator.Tests.Controllers
                 $"Expected sandbox_version in drift list; got [{string.Join(", ", driftFields.Select(f => f.FieldPath))}].");
         }
 
+        // ============================================================================
+        // 3. Two TenantConfs differing only in the ORDER of enabled_locales are equivalent
+        //    from HasConfigurationChanged's point of view. Regression guard for H2 / MR !3
+        //    rufus review: V1TenantController.AreValuesEqual previously used an order-
+        //    sensitive index loop for arrays while V1TenantEntityController used order-
+        //    insensitive set comparison. Auth0 reorders enabled_locales server-side, so the
+        //    tenant controller's old behaviour produced spurious drift on every reconcile.
+        //    Both controllers now share DriftComparison.AreArraysEqualOrderInsensitive.
+        // ============================================================================
+
+        [TestMethod]
+        public void HasConfigurationChanged_EnabledLocalesReordered_ReturnsFalse()
+        {
+            var controller = BuildController();
+
+            // Same locale set, different order — Auth0 reorders server-side after PATCH.
+            var lastConf = new Hashtable
+            {
+                ["friendly_name"] = "Acme",
+                ["enabled_locales"] = new object[] { "en", "fr", "es" },
+            };
+
+            var desiredConf = new TenantConf
+            {
+                FriendlyName = "Acme",
+                EnabledLocales = new List<string> { "es", "en", "fr" },
+            };
+
+            var (changed, driftFields) = InvokeHasConfigurationChanged(controller, lastConf, desiredConf);
+
+            Assert.IsFalse(changed,
+                $"HasConfigurationChanged must return false when enabled_locales differs only in " +
+                $"element order (Auth0 reorders list-shaped fields server-side). Drift fields: " +
+                $"[{string.Join(", ", driftFields.Select(f => f.FieldPath))}]");
+            Assert.AreEqual(0, driftFields.Count,
+                $"Drift list must be empty; got [{string.Join(", ", driftFields.Select(f => f.FieldPath))}].");
+        }
+
         // ---- Test scaffolding ----
 
         private static V1TenantController BuildController()

--- a/src/Alethic.Auth0.Operator.Tests/Controllers/V1TenantControllerTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Controllers/V1TenantControllerTests.cs
@@ -1,78 +1,153 @@
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
 using Alethic.Auth0.Operator.Controllers;
+using Alethic.Auth0.Operator.Core.Models.Tenant;
+using Alethic.Auth0.Operator.Models;
+using Alethic.Auth0.Operator.Options;
 
+using KubeOps.Abstractions.Queue;
+using KubeOps.KubernetesClient;
+
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Moq;
 
 namespace Alethic.Auth0.Operator.Tests.Controllers
 {
     /// <summary>
     /// Regression guard for F1 / LA-RF-81: A0Tenant drift detection must NOT include
-    /// <c>sandbox_versions_available</c>, which is an Auth0-managed read-only catalog field that
+    /// <c>sandbox_versions_available</c>, an Auth0-managed read-only catalog field that
     /// Auth0 mutates independently of operator writes. Including it caused spurious
-    /// "DRIFT DETECTED" events to fire on ~295 A0Tenant reconciles over a 7-day Datadog window,
+    /// "DRIFT DETECTED" events on ~295 A0Tenant reconciles over a 7-day Datadog window,
     /// triggering full-config PATCHes that contributed to insufficient_scope chains downstream.
     /// <para>
-    /// The test reflects on <c>V1TenantController.GetIncludedFields()</c> directly. Because the
-    /// upstream filter <c>FilterFieldsForComparison</c> keeps only keys whose name is in
-    /// <c>GetIncludedFields()</c>, a field absent from that list mathematically cannot appear in
-    /// the resulting <c>driftFields</c> list — so this reflection-level assertion is functionally
-    /// equivalent to (and tighter than) driving <c>HasConfigurationChanged</c> end-to-end.
-    /// </para>
-    /// <para>
-    /// This test must pass on this branch and MUST FAIL if <c>sandbox_versions_available</c> is
-    /// re-added to <see cref="V1TenantController.GetIncludedFields"/>.
+    /// The tests below drive the controller end-to-end through its private
+    /// <c>HasConfigurationChanged</c> method via reflection on a properly-constructed
+    /// instance (M2 / LA-RF-81 code review). This is functionally equivalent to a public
+    /// API call and replaces the previous brittle <c>RuntimeHelpers.GetUninitializedObject</c>
+    /// pattern, which depended on <c>GetIncludedFields</c> having no state — true today,
+    /// silently breakable tomorrow.
     /// </para>
     /// </summary>
     [TestClass]
     public class V1TenantControllerTests
     {
-        [TestMethod]
-        public void GetIncludedFields_DoesNotIncludeSandboxVersionsAvailable()
-        {
-            var includedFields = InvokeGetIncludedFields();
-
-            CollectionAssert.DoesNotContain(
-                includedFields,
-                "sandbox_versions_available",
-                "sandbox_versions_available is an Auth0-managed read-only catalog field that mutates " +
-                "independently of operator writes. Including it in drift detection produces spurious " +
-                "DRIFT DETECTED events. If this assertion fails, see the LA-RF-81 plan and the " +
-                "Datadog investigation that motivated its removal before re-adding it.");
-        }
+        // ============================================================================
+        // 1. Two TenantConfs differing only in SandboxVersionsAvailable are equivalent
+        //    from HasConfigurationChanged's point of view — i.e. drift NOT detected.
+        // ============================================================================
 
         [TestMethod]
-        public void GetIncludedFields_StillIncludesSandboxVersion()
+        public void HasConfigurationChanged_TwoTenantConfsDifferingOnlyInSandboxVersionsAvailable_ReturnsFalse()
         {
-            // sandbox_version (the singular, writable spec field) MUST remain in drift detection.
-            // It's the user-controllable choice between the available sandbox runtime versions,
-            // and the operator owns reconciling it to spec.
-            var includedFields = InvokeGetIncludedFields();
+            var controller = BuildController();
 
-            CollectionAssert.Contains(
-                includedFields,
-                "sandbox_version",
-                "sandbox_version (singular, writable) is the user-controllable spec field; " +
-                "it must remain in drift detection. Don't conflate it with the read-only " +
-                "sandbox_versions_available catalog field.");
+            // The `lastConf` Hashtable simulates what Auth0 returned (transformed through
+            // TransformToSystemTextJson<Hashtable>). Both confs have identical sandbox_version
+            // (the writable field). Only sandbox_versions_available differs — that's the
+            // Auth0-managed read-only catalog field that must be filtered out by GetIncludedFields.
+            var lastConf = new Hashtable
+            {
+                ["friendly_name"] = "Acme",
+                ["sandbox_version"] = "18",
+                ["sandbox_versions_available"] = new object[] { "16", "18" },
+            };
+
+            var desiredConf = new TenantConf
+            {
+                FriendlyName = "Acme",
+                SandboxVersion = "18",
+                SandboxVersionsAvailable = new[] { "16", "18", "20" }, // <-- differs
+            };
+
+            var (changed, driftFields) = InvokeHasConfigurationChanged(controller, lastConf, desiredConf);
+
+            Assert.IsFalse(changed,
+                $"HasConfigurationChanged must return false when the two configs differ only in " +
+                $"sandbox_versions_available (an Auth0-managed read-only field). Drift fields: " +
+                $"[{string.Join(", ", driftFields.Select(f => f.FieldPath))}]");
+            Assert.AreEqual(0, driftFields.Count,
+                $"Drift list must be empty; got [{string.Join(", ", driftFields.Select(f => f.FieldPath))}].");
         }
 
-        private static string[] InvokeGetIncludedFields()
-        {
-            // Construct a default V1TenantController via a parameter-less helper would require
-            // a full DI graph. We only need the method's *return value*, which is a pure function
-            // of the type — reflect on the protected instance method via an uninitialized
-            // instance, which is sufficient because GetIncludedFields has no state dependencies.
-            var controller = (V1TenantController)System.Runtime.CompilerServices.RuntimeHelpers
-                .GetUninitializedObject(typeof(V1TenantController));
+        // ============================================================================
+        // 2. sandbox_version (singular) drift IS detected — sanity-check that we didn't
+        //    accidentally over-filter and wipe out the writable sibling field.
+        // ============================================================================
 
+        [TestMethod]
+        public void HasConfigurationChanged_TwoTenantConfsDifferingOnlyInSandboxVersion_ReturnsTrue()
+        {
+            var controller = BuildController();
+
+            var lastConf = new Hashtable
+            {
+                ["friendly_name"] = "Acme",
+                ["sandbox_version"] = "16",
+            };
+
+            var desiredConf = new TenantConf
+            {
+                FriendlyName = "Acme",
+                SandboxVersion = "18", // <-- differs
+            };
+
+            var (changed, driftFields) = InvokeHasConfigurationChanged(controller, lastConf, desiredConf);
+
+            Assert.IsTrue(changed,
+                "HasConfigurationChanged must detect drift on the user-writable sandbox_version " +
+                "field; otherwise the user's spec value can never be reconciled back to Auth0.");
+            Assert.IsTrue(driftFields.Any(f => f.FieldPath == "sandbox_version"),
+                $"Expected sandbox_version in drift list; got [{string.Join(", ", driftFields.Select(f => f.FieldPath))}].");
+        }
+
+        // ---- Test scaffolding ----
+
+        private static V1TenantController BuildController()
+        {
+            var kube = new Mock<IKubernetesClient>(MockBehavior.Loose).Object;
+            EntityRequeue<V1Tenant> requeue = (_, __) => { };
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var options = Microsoft.Extensions.Options.Options.Create(new OperatorOptions());
+            return new V1TenantController(
+                kube,
+                requeue,
+                cache,
+                NullLogger<V1TenantController>.Instance,
+                options);
+        }
+
+        /// <summary>
+        /// Calls the private <c>HasConfigurationChanged(V1Tenant, Hashtable?, TenantConf, out List&lt;DriftField&gt;)</c>
+        /// via reflection. Reflection is used here only because the production method is
+        /// private; the test exercises real instance state (logger, included-field filter,
+        /// hashtable normalization, drift computation) end-to-end.
+        /// </summary>
+        private static (bool changed, List<DriftField> driftFields) InvokeHasConfigurationChanged(
+            V1TenantController controller, Hashtable? lastConf, TenantConf desiredConf)
+        {
             var method = typeof(V1TenantController).GetMethod(
-                "GetIncludedFields",
+                "HasConfigurationChanged",
                 BindingFlags.Instance | BindingFlags.NonPublic);
-            Assert.IsNotNull(method, "V1TenantController.GetIncludedFields not found via reflection.");
+            Assert.IsNotNull(method, "V1TenantController.HasConfigurationChanged(V1Tenant, Hashtable?, TenantConf, out List<DriftField>) not found via reflection.");
 
-            return (string[])method!.Invoke(controller, null)!;
+            var entity = new V1Tenant
+            {
+                Metadata = new k8s.Models.V1ObjectMeta { Name = "t1", NamespaceProperty = "default" },
+                Spec = new V1Tenant.SpecDef { Conf = desiredConf },
+                Status = new V1Tenant.StatusDef(),
+            };
+
+            var args = new object?[] { entity, lastConf, desiredConf, null };
+            var result = (bool)method!.Invoke(controller, args)!;
+            var drift = (List<DriftField>)args[3]!;
+            return (result, drift);
         }
     }
 }

--- a/src/Alethic.Auth0.Operator.Tests/Controllers/V1TenantControllerTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Controllers/V1TenantControllerTests.cs
@@ -1,0 +1,78 @@
+using System.Linq;
+using System.Reflection;
+
+using Alethic.Auth0.Operator.Controllers;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Alethic.Auth0.Operator.Tests.Controllers
+{
+    /// <summary>
+    /// Regression guard for F1 / LA-RF-81: A0Tenant drift detection must NOT include
+    /// <c>sandbox_versions_available</c>, which is an Auth0-managed read-only catalog field that
+    /// Auth0 mutates independently of operator writes. Including it caused spurious
+    /// "DRIFT DETECTED" events to fire on ~295 A0Tenant reconciles over a 7-day Datadog window,
+    /// triggering full-config PATCHes that contributed to insufficient_scope chains downstream.
+    /// <para>
+    /// The test reflects on <c>V1TenantController.GetIncludedFields()</c> directly. Because the
+    /// upstream filter <c>FilterFieldsForComparison</c> keeps only keys whose name is in
+    /// <c>GetIncludedFields()</c>, a field absent from that list mathematically cannot appear in
+    /// the resulting <c>driftFields</c> list — so this reflection-level assertion is functionally
+    /// equivalent to (and tighter than) driving <c>HasConfigurationChanged</c> end-to-end.
+    /// </para>
+    /// <para>
+    /// This test must pass on this branch and MUST FAIL if <c>sandbox_versions_available</c> is
+    /// re-added to <see cref="V1TenantController.GetIncludedFields"/>.
+    /// </para>
+    /// </summary>
+    [TestClass]
+    public class V1TenantControllerTests
+    {
+        [TestMethod]
+        public void GetIncludedFields_DoesNotIncludeSandboxVersionsAvailable()
+        {
+            var includedFields = InvokeGetIncludedFields();
+
+            CollectionAssert.DoesNotContain(
+                includedFields,
+                "sandbox_versions_available",
+                "sandbox_versions_available is an Auth0-managed read-only catalog field that mutates " +
+                "independently of operator writes. Including it in drift detection produces spurious " +
+                "DRIFT DETECTED events. If this assertion fails, see the LA-RF-81 plan and the " +
+                "Datadog investigation that motivated its removal before re-adding it.");
+        }
+
+        [TestMethod]
+        public void GetIncludedFields_StillIncludesSandboxVersion()
+        {
+            // sandbox_version (the singular, writable spec field) MUST remain in drift detection.
+            // It's the user-controllable choice between the available sandbox runtime versions,
+            // and the operator owns reconciling it to spec.
+            var includedFields = InvokeGetIncludedFields();
+
+            CollectionAssert.Contains(
+                includedFields,
+                "sandbox_version",
+                "sandbox_version (singular, writable) is the user-controllable spec field; " +
+                "it must remain in drift detection. Don't conflate it with the read-only " +
+                "sandbox_versions_available catalog field.");
+        }
+
+        private static string[] InvokeGetIncludedFields()
+        {
+            // Construct a default V1TenantController via a parameter-less helper would require
+            // a full DI graph. We only need the method's *return value*, which is a pure function
+            // of the type — reflect on the protected instance method via an uninitialized
+            // instance, which is sufficient because GetIncludedFields has no state dependencies.
+            var controller = (V1TenantController)System.Runtime.CompilerServices.RuntimeHelpers
+                .GetUninitializedObject(typeof(V1TenantController));
+
+            var method = typeof(V1TenantController).GetMethod(
+                "GetIncludedFields",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.IsNotNull(method, "V1TenantController.GetIncludedFields not found via reflection.");
+
+            return (string[])method!.Invoke(controller, null)!;
+        }
+    }
+}

--- a/src/Alethic.Auth0.Operator.Tests/TestSupport/CapturingLogger.cs
+++ b/src/Alethic.Auth0.Operator.Tests/TestSupport/CapturingLogger.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+
+using Microsoft.Extensions.Logging;
+
+namespace Alethic.Auth0.Operator.Tests.TestSupport
+{
+    /// <summary>
+    /// A single captured log entry — level, formatted message text, and exception.
+    /// </summary>
+    internal sealed class CapturingLogEntry
+    {
+        public LogLevel Level { get; init; }
+        public string Message { get; init; } = string.Empty;
+        public Exception? Exception { get; init; }
+    }
+
+    /// <summary>
+    /// Minimal capturing <see cref="ILogger"/>. Records the formatted message — which, for
+    /// the structured-JSON helpers under test (<c>LogAuth0Read</c> / <c>LogAuth0Write</c>
+    /// / <c>LogWarningJson</c>), is the raw JSON payload. Lifted out of
+    /// <c>V1ControllerRateLimitObservabilityTests</c> in M3 (LA-RF-81 code review) so
+    /// multiple test classes can share the same scaffold without duplication.
+    /// </summary>
+    internal sealed class CapturingLogger : ILogger
+    {
+        public List<CapturingLogEntry> Entries { get; } = new();
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add(new CapturingLogEntry
+            {
+                Level = logLevel,
+                Message = formatter(state, exception),
+                Exception = exception,
+            });
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+
+    /// <summary>
+    /// Adapts a non-generic <see cref="ILogger"/> into the <see cref="ILogger{T}"/> that
+    /// controller constructors require, so tests can supply a single capturing logger.
+    /// </summary>
+    internal sealed class TypedLoggerAdapter<T> : ILogger<T>
+    {
+        private readonly ILogger _inner;
+        public TypedLoggerAdapter(ILogger inner) { _inner = inner; }
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => _inner.BeginScope(state)!;
+        public bool IsEnabled(LogLevel logLevel) => _inner.IsEnabled(logLevel);
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => _inner.Log(logLevel, eventId, state, exception, formatter);
+    }
+}

--- a/src/Alethic.Auth0.Operator/Controllers/DriftComparison.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/DriftComparison.cs
@@ -1,0 +1,52 @@
+using System;
+
+namespace Alethic.Auth0.Operator.Controllers
+{
+    /// <summary>
+    /// Shared drift-comparison primitives consumed by both <see cref="V1TenantController"/>
+    /// and <see cref="V1TenantEntityController{TEntity, TConf, TApi}"/>. Promoted from the
+    /// per-controller copies so the two drift-detection paths cannot diverge silently —
+    /// see decisions.md entry "2026-05-19 — Unified array-comparison semantics across all
+    /// drift controllers" for the rationale (Auth0 reorders list-shaped fields like
+    /// <c>enabled_locales</c> server-side; preserving order in comparison produces
+    /// spurious drift).
+    /// </summary>
+    internal static class DriftComparison
+    {
+        /// <summary>
+        /// Compares two collections as sets (order-insensitive) using a caller-supplied
+        /// element-equality callback. O(n²) set-membership match — bounded by Auth0 DTO
+        /// shapes which never exceed a few dozen entries per array field.
+        /// </summary>
+        /// <param name="leftArray">First collection materialized as an object array</param>
+        /// <param name="rightArray">Second collection materialized as an object array</param>
+        /// <param name="valuesEqual">Per-element equality predicate (typically the caller's
+        /// own <c>AreValuesEqual</c> so nested hashtables / arrays recurse correctly).</param>
+        /// <returns>True if the two arrays contain the same elements regardless of order.</returns>
+        internal static bool AreArraysEqualOrderInsensitive(
+            object[] leftArray,
+            object[] rightArray,
+            Func<object?, object?, bool> valuesEqual)
+        {
+            if (leftArray.Length != rightArray.Length)
+                return false;
+
+            foreach (var leftItem in leftArray)
+            {
+                bool foundMatch = false;
+                foreach (var rightItem in rightArray)
+                {
+                    if (valuesEqual(leftItem, rightItem))
+                    {
+                        foundMatch = true;
+                        break;
+                    }
+                }
+                if (!foundMatch)
+                    return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Alethic.Auth0.Operator/Controllers/DriftLogContext.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/DriftLogContext.cs
@@ -85,6 +85,28 @@ namespace Alethic.Auth0.Operator.Controllers
             "private_key",
         };
 
+        /// <summary>
+        /// Exact rendered values that legitimately contain a <see cref="SecretShapedSubstrings"/>
+        /// marker but are typed Auth0 OAuth enum members, not secrets. The leading/trailing quotes
+        /// are intentional — <see cref="LogValueFormatter.FormatValueForLogging"/> wraps string
+        /// values in double quotes, so matching on the quoted form prevents this allowlist from
+        /// accidentally letting a free-form user-controlled string field (e.g. a connection
+        /// description containing the literal "client_secret_post") slip past the redaction guard.
+        /// <para>
+        /// Source: <see cref="Alethic.Auth0.Operator.Core.Models.Client.TokenEndpointAuthMethod"/>
+        /// declares <c>client_secret_post</c> and <c>client_secret_basic</c>. <c>client_secret_jwt</c>
+        /// is a valid Auth0-returned value (OIDC core spec) that our enum doesn't currently model
+        /// but Auth0 may emit on read — allowlist it pre-emptively so a future enum addition or a
+        /// raw before-value from Auth0 doesn't false-trip the guard.
+        /// </para>
+        /// </summary>
+        private static readonly HashSet<string> SecretShapedAllowedExactValues = new(StringComparer.Ordinal)
+        {
+            "\"client_secret_post\"",
+            "\"client_secret_basic\"",
+            "\"client_secret_jwt\"",
+        };
+
         public string FieldPath { get; }
 
         public DriftChangeType ChangeType { get; }
@@ -111,6 +133,13 @@ namespace Alethic.Auth0.Operator.Controllers
         private static void EnsureNoSecretShape(string paramName, string? value)
         {
             if (string.IsNullOrEmpty(value))
+                return;
+
+            // Allowlist exact rendered forms of typed OAuth enum members whose string value
+            // legitimately contains a SecretShapedSubstrings marker. Matching the *quoted* form
+            // (as produced by LogValueFormatter.FormatValueForLogging) ensures we don't allowlist
+            // a user-controlled string field that merely contains the same substring.
+            if (SecretShapedAllowedExactValues.Contains(value))
                 return;
 
             foreach (var marker in SecretShapedSubstrings)

--- a/src/Alethic.Auth0.Operator/Controllers/LogValueFormatter.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/LogValueFormatter.cs
@@ -29,14 +29,18 @@ namespace Alethic.Auth0.Operator.Controllers
         /// <summary>
         /// Returns true if <paramref name="key"/> names an Auth0 / connection-options field whose
         /// value is sensitive (a secret, credential, signing key, etc.) and must never be written
-        /// to the structured drift-log payload. Matching is case-insensitive substring matching —
-        /// covers <c>client_secret</c>, <c>bind_credentials</c>, <c>password</c>, <c>api_secret</c>,
-        /// <c>signing_cert</c>, <c>signing_key</c>, <c>kerberos</c>, <c>private_key</c>,
-        /// <c>api_key</c>, <c>client_assertion</c>, <c>certificate</c>, <c>pfx</c>, plus the three
-        /// OAuth token fields (<c>access_token</c>, <c>refresh_token</c>, <c>id_token</c>) when
-        /// they appear as the trailing <c>_</c>- or <c>.</c>-bounded segment of the key. The
-        /// token rule is intentionally narrow — a plain <c>"token"</c> substring would over-match
-        /// legitimate non-secret fields like <c>token_endpoint</c>,
+        /// to the structured drift-log payload. Matching is case-insensitive substring matching
+        /// for most keywords; <c>pfx</c> and the OAuth token names match only as
+        /// <c>_</c>/<c>.</c>-bounded segments. Covers <c>client_secret</c>,
+        /// <c>bind_credentials</c>, <c>password</c>, <c>api_secret</c>, <c>signing_cert</c>,
+        /// <c>signing_key</c>, <c>kerberos</c>, <c>private_key</c>, <c>api_key</c>,
+        /// <c>client_assertion</c>, <c>certificate</c>, <c>pfx</c> (as a complete segment — see
+        /// <see cref="ContainsSegment"/>), plus the three OAuth token fields
+        /// (<c>access_token</c>, <c>refresh_token</c>, <c>id_token</c>) when they appear as the
+        /// trailing <c>_</c>- or <c>.</c>-bounded segment of the key. The segment-bounded rules
+        /// are intentionally narrow — a plain <c>Contains</c> on <c>"pfx"</c> would over-match
+        /// keys like <c>prefix_url</c> and <c>spfx_config</c>, and a plain <c>Contains</c> on
+        /// <c>"token"</c> would over-match <c>token_endpoint</c>,
         /// <c>token_endpoint_auth_method</c>, and <c>access_token_lifetime_in_seconds</c>.
         /// False-positives (e.g. a user-facing description that happens to contain the word
         /// <c>password</c>) are acceptable; false-negatives are not.
@@ -60,7 +64,7 @@ namespace Alethic.Auth0.Operator.Controllers
                 || lower.Contains("api_key", StringComparison.Ordinal)
                 || lower.Contains("client_assertion", StringComparison.Ordinal)
                 || lower.Contains("certificate", StringComparison.Ordinal)
-                || lower.Contains("pfx", StringComparison.Ordinal)
+                || ContainsSegment(lower, "pfx")
                 || IsOAuthTokenKey(lower);
         }
 
@@ -77,6 +81,29 @@ namespace Alethic.Auth0.Operator.Controllers
             return EndsWithSegment(lower, "access_token")
                 || EndsWithSegment(lower, "refresh_token")
                 || EndsWithSegment(lower, "id_token");
+        }
+
+        /// <summary>
+        /// Returns true when <paramref name="segment"/> appears in <paramref name="key"/> as a
+        /// complete <c>_</c>- or <c>.</c>-bounded segment (or equals the whole key). Matches
+        /// <c>pfx</c>, <c>cert.pfx</c>, <c>pfx_data</c>, <c>oauth.pfx_blob</c>; does NOT match
+        /// <c>prefix_url</c> or <c>spfx_config</c>. Used by <see cref="IsSensitiveKey"/> to
+        /// redact <c>pfx</c>-bearing fields without over-matching keys that merely contain the
+        /// three letters as a non-boundary substring.
+        /// </summary>
+        private static bool ContainsSegment(string key, string segment)
+        {
+            int idx = 0;
+            while ((idx = key.IndexOf(segment, idx, StringComparison.Ordinal)) >= 0)
+            {
+                var leftOk = idx == 0 || key[idx - 1] == '_' || key[idx - 1] == '.';
+                var endIdx = idx + segment.Length;
+                var rightOk = endIdx == key.Length || key[endIdx] == '_' || key[endIdx] == '.';
+                if (leftOk && rightOk)
+                    return true;
+                idx = endIdx;
+            }
+            return false;
         }
 
         /// <summary>

--- a/src/Alethic.Auth0.Operator/Controllers/V1ConnectionController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1ConnectionController.cs
@@ -503,11 +503,11 @@ namespace Alethic.Auth0.Operator.Controllers
                         status = "warning",
                         metadata = req.Metadata
                     });
-                    LogAuth0Write($"Resetting Auth0 connection metadata with ID: {id}", "A0Connection", conf.Name ?? "unknown", "unknown", "reset_connection_metadata", driftContext);
+                    LogAuth0Write($"Resetting Auth0 connection metadata with ID: {id}", "A0Connection", conf.Name ?? "unknown", defaultNamespace, "reset_connection_metadata", driftContext);
                     await api.Connections.UpdateAsync(id, new ConnectionUpdateRequest { Metadata = new Hashtable() }, cancellationToken);
                 }
 
-                LogAuth0Write($"Updating Auth0 connection with ID: {id}", "A0Connection", conf.Name ?? "unknown", "unknown", "update_connection", driftContext);
+                LogAuth0Write($"Updating Auth0 connection with ID: {id}", "A0Connection", conf.Name ?? "unknown", defaultNamespace, "update_connection", driftContext);
                 await api.Connections.UpdateAsync(id, req, cancellationToken);
                 Logger.LogInformationJson($"{EntityTypeName} successfully updated connection in Auth0 with ID: {id}, name: {conf.Name} and strategy: {conf.Strategy}", new
                 {

--- a/src/Alethic.Auth0.Operator/Controllers/V1Controller.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1Controller.cs
@@ -697,26 +697,40 @@ namespace Alethic.Auth0.Operator.Controllers
 
                 // F4 (LA-RF-81): floored value (seconds, no jitter) captured here so the
                 // structured warn log surfaces what Auth0's authoritative reset hint dictated
-                // before we layered jitter on top. Jitter is applied to the actual requeue
-                // delay only (below), to avoid multi-pod thundering-herd on the same tenant.
-                var requeueAfterSeconds = (int)Math.Floor(baseDelay.TotalSeconds);
+                // before we layered jitter on top. Jitter is computed once below and used for
+                // both the warn log and the actual Requeue call, to avoid multi-pod
+                // thundering-herd on the same tenant.
+                var requeueFloorSeconds = (int)Math.Floor(baseDelay.TotalSeconds);
                 var rateLimitResetUtc = e.RateLimit?.Reset?.ToUniversalTime().ToString("o");
+
+                // F4 (LA-RF-81): apply one-sided [1.0, 1.2) jitter after the floor; clamp
+                // back to the floor if (defensively) it would fall below. Floor stays
+                // authoritative as the minimum. Computed once so the structured log and
+                // the Requeue call carry the same value.
+                var jitteredDelay = ApplyRateLimitJitter(baseDelay, RateLimitRequeueFloor);
+                var requeueAfterSeconds = (int)jitteredDelay.TotalSeconds;
 
                 try
                 {
                     var duration = DateTimeOffset.UtcNow - startTime;
-                    Logger.LogWarningJson($"Auth0 rate limit exceeded for {EntityTypeName} {entity.Namespace()}/{entity.Name()}: Limit={e.RateLimit?.Limit}, Remaining={e.RateLimit?.Remaining}, Reset={e.RateLimit?.Reset}, Duration={duration.TotalMilliseconds}ms", new {
+                    Logger.LogWarningJson($"Auth0 rate limit exceeded for {EntityTypeName} {entity.Namespace()}/{entity.Name()}: Limit={e.RateLimit?.Limit}, Remaining={e.RateLimit?.Remaining}, Reset={e.RateLimit?.Reset}, Duration={duration.TotalMilliseconds}ms, RequeueAfter={jitteredDelay}", new {
                         entityTypeName = EntityTypeName,
                         entityNamespace = entity.Namespace(),
                         entityName = entity.Name(),
                         rateLimitLimit = e.RateLimit?.Limit,
                         rateLimitRemaining = e.RateLimit?.Remaining,
                         rateLimitReset = e.RateLimit?.Reset,
-                        // F4 (LA-RF-81): facet-friendly fields. `auth0RateLimitResetUtc`
-                        // is the SDK-parsed reset hint as ISO-8601 UTC; `auth0RequeueAfterSeconds`
-                        // is the floored delay (before jitter) we'll requeue after.
+                        // F4 (LA-RF-81): facet-friendly fields.
+                        //   `auth0RateLimitResetUtc`   — SDK-parsed reset hint as ISO-8601 UTC.
+                        //   `auth0RequeueFloorSeconds` — floored pre-jitter delay (the floor
+                        //                                Auth0's reset hint dictates).
+                        //   `auth0RequeueAfterSeconds` — actual post-jitter delay used by
+                        //                                Requeue(...). What the operator
+                        //                                will *actually* wait.
                         auth0RateLimitResetUtc = rateLimitResetUtc,
+                        auth0RequeueFloorSeconds = requeueFloorSeconds,
                         auth0RequeueAfterSeconds = requeueAfterSeconds,
+                        rescheduleAfter = jitteredDelay.ToString(),
                         durationMs = duration.TotalMilliseconds
                     });
                     await ReconcileWarningAsync(entity, "RateLimit", e.ApiError?.Message ?? e.Message, cancellationToken);
@@ -730,13 +744,6 @@ namespace Alethic.Auth0.Operator.Controllers
                     }, e2);
                 }
 
-                // F4 (LA-RF-81): apply ±20% jitter after the floor; clamp back to the floor
-                // if jitter would push below it. Floor stays authoritative as the minimum.
-                var jitteredDelay = ApplyRateLimitJitter(baseDelay, RateLimitRequeueFloor);
-
-                Logger.LogWarningJson($"Rate limit exceeded, rescheduling reconciliation after {jitteredDelay}", new {
-                    rescheduleAfter = jitteredDelay.ToString()
-                });
                 Requeue(entity, jitteredDelay);
             }
             catch (RetryException e)
@@ -894,22 +901,24 @@ namespace Alethic.Auth0.Operator.Controllers
         /// </summary>
         internal static readonly TimeSpan RateLimitRequeueFloor = TimeSpan.FromMinutes(1);
 
-        // F4 (LA-RF-81): testability seam. The jitter factor source is injectable so the
-        // `RateLimitApiException_RequeueDelay_AppliesJitterWithinTwentyPercentOfResetHint`
-        // test can drive the boundaries deterministically. Production uses
-        // <see cref="Random.Shared"/>. Internal — never expose on the public surface.
-        internal static Func<double> RateLimitJitterSampler { get; set; } = static () => Random.Shared.NextDouble();
+        /// <summary>
+        /// F4 (LA-RF-81): testability seam for jitter sampling. Tests override this on a
+        /// <c>TestController</c> subclass to drive jitter deterministically (see
+        /// <c>V1ControllerRateLimitObservabilityTests.TestController</c>). Production
+        /// uses <see cref="Random.Shared"/>. Returns a value in <c>[0.0, 1.0)</c>.
+        /// </summary>
+        protected virtual double SampleRateLimitJitter() => Random.Shared.NextDouble();
 
         /// <summary>
-        /// Applies ±20% jitter to <paramref name="baseDelay"/> and clamps the result back
-        /// up to <paramref name="floor"/> if jitter would push it below. Order matters:
-        /// floor is applied first by the caller, then jitter, then re-clamp — so the floor
-        /// is the strict minimum requeue delay regardless of jitter direction.
+        /// Applies one-sided <c>[1.0, 1.2)</c> jitter to <paramref name="baseDelay"/> and clamps
+        /// the result back up to <paramref name="floor"/> if (for any reason) it would fall
+        /// below. Jitter only spreads upward so we never requeue sooner than the SDK's reset
+        /// hint. Floor stays authoritative as the absolute minimum requeue delay.
         /// </summary>
-        internal static TimeSpan ApplyRateLimitJitter(TimeSpan baseDelay, TimeSpan floor)
+        protected TimeSpan ApplyRateLimitJitter(TimeSpan baseDelay, TimeSpan floor)
         {
-            // factor ∈ [0.8, 1.2): NextDouble() ∈ [0,1) → 0.8 + (∈[0,1) * 0.4)
-            var jitterFactor = 0.8 + (RateLimitJitterSampler() * 0.4);
+            // factor ∈ [1.0, 1.2): SampleRateLimitJitter() ∈ [0,1) → 1.0 + (∈[0,1) * 0.2)
+            var jitterFactor = 1.0 + (SampleRateLimitJitter() * 0.2);
             var jittered = TimeSpan.FromTicks((long)(baseDelay.Ticks * jitterFactor));
             return jittered < floor ? floor : jittered;
         }

--- a/src/Alethic.Auth0.Operator/Controllers/V1Controller.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1Controller.cs
@@ -647,11 +647,18 @@ namespace Alethic.Auth0.Operator.Controllers
                 try
                 {
                     var duration = DateTimeOffset.UtcNow - startTime;
+                    var auth0StatusCode = (int)e.StatusCode;
+                    var auth0RetryableHint = IsAuth0RetryableStatus(auth0StatusCode);
                     Logger.LogErrorJson($"Auth0 API error during reconciliation for {EntityTypeName} {entity.Namespace()}/{entity.Name()}: Status={e.StatusCode}, ErrorCode={e.ApiError?.ErrorCode}, Message={e.ApiError?.Message}, Duration={duration.TotalMilliseconds}ms", new {
                         entityTypeName = EntityTypeName,
                         entityNamespace = entity.Namespace(),
                         entityName = entity.Name(),
                         statusCode = e.StatusCode.ToString(),
+                        // F4 (LA-RF-81): structured fields for Datadog facets — numeric status
+                        // and a retryable hint (429/5xx) so investigators can filter without
+                        // string-matching the status enum.
+                        auth0StatusCode = auth0StatusCode,
+                        auth0RetryableHint = auth0RetryableHint,
                         errorCode = e.ApiError?.ErrorCode,
                         apiErrorMessage = e.ApiError?.Message,
                         durationMs = duration.TotalMilliseconds
@@ -683,38 +690,54 @@ namespace Alethic.Auth0.Operator.Controllers
             }
             catch (RateLimitApiException e)
             {
+                // calculate next attempt time, floored to one minute
+                var baseDelay = e.RateLimit?.Reset is DateTimeOffset r ? r - DateTimeOffset.Now : TimeSpan.FromMinutes(1);
+                if (baseDelay < TimeSpan.FromMinutes(1))
+                    baseDelay = TimeSpan.FromMinutes(1);
+
+                // F4 (LA-RF-81): floored value (seconds, no jitter) captured here so the
+                // structured warn log surfaces what Auth0's authoritative reset hint dictated
+                // before we layered jitter on top. Jitter is applied to the actual requeue
+                // delay only (below), to avoid multi-pod thundering-herd on the same tenant.
+                var requeueAfterSeconds = (int)Math.Floor(baseDelay.TotalSeconds);
+                var rateLimitResetUtc = e.RateLimit?.Reset?.ToUniversalTime().ToString("o");
+
                 try
                 {
                     var duration = DateTimeOffset.UtcNow - startTime;
-                    Logger.LogWarningJson($"Auth0 rate limit exceeded for {EntityTypeName} {entity.Namespace()}/{entity.Name()}: Limit={e.RateLimit?.Limit}, Remaining={e.RateLimit?.Remaining}, Reset={e.RateLimit?.Reset}, Duration={duration.TotalMilliseconds}ms", new { 
+                    Logger.LogWarningJson($"Auth0 rate limit exceeded for {EntityTypeName} {entity.Namespace()}/{entity.Name()}: Limit={e.RateLimit?.Limit}, Remaining={e.RateLimit?.Remaining}, Reset={e.RateLimit?.Reset}, Duration={duration.TotalMilliseconds}ms", new {
                         entityTypeName = EntityTypeName,
-                        entityNamespace = entity.Namespace(), 
-                        entityName = entity.Name(), 
+                        entityNamespace = entity.Namespace(),
+                        entityName = entity.Name(),
                         rateLimitLimit = e.RateLimit?.Limit,
                         rateLimitRemaining = e.RateLimit?.Remaining,
                         rateLimitReset = e.RateLimit?.Reset,
-                        durationMs = duration.TotalMilliseconds 
+                        // F4 (LA-RF-81): facet-friendly fields. `auth0RateLimitResetUtc`
+                        // is the SDK-parsed reset hint as ISO-8601 UTC; `auth0RequeueAfterSeconds`
+                        // is the floored delay (before jitter) we'll requeue after.
+                        auth0RateLimitResetUtc = rateLimitResetUtc,
+                        auth0RequeueAfterSeconds = requeueAfterSeconds,
+                        durationMs = duration.TotalMilliseconds
                     });
                     await ReconcileWarningAsync(entity, "RateLimit", e.ApiError?.Message ?? e.Message, cancellationToken);
                 }
                 catch (Exception e2)
                 {
-                    Logger.LogCriticalJson($"Unexpected exception creating event for {EntityTypeName} {entity.Namespace()}/{entity.Name()}", new { 
+                    Logger.LogCriticalJson($"Unexpected exception creating event for {EntityTypeName} {entity.Namespace()}/{entity.Name()}", new {
                         entityTypeName = EntityTypeName,
-                        entityNamespace = entity.Namespace(), 
-                        entityName = entity.Name() 
+                        entityNamespace = entity.Namespace(),
+                        entityName = entity.Name()
                     }, e2);
                 }
 
-                // calculate next attempt time, floored to one minute
-                var n = e.RateLimit?.Reset is DateTimeOffset r ? r - DateTimeOffset.Now : TimeSpan.FromMinutes(1);
-                if (n < TimeSpan.FromMinutes(1))
-                    n = TimeSpan.FromMinutes(1);
+                // F4 (LA-RF-81): apply ±20% jitter after the floor; clamp back to the floor
+                // if jitter would push below it. Floor stays authoritative as the minimum.
+                var jitteredDelay = ApplyRateLimitJitter(baseDelay, RateLimitRequeueFloor);
 
-                Logger.LogWarningJson($"Rate limit exceeded, rescheduling reconciliation after {n}", new { 
-                    rescheduleAfter = n.ToString() 
+                Logger.LogWarningJson($"Rate limit exceeded, rescheduling reconciliation after {jitteredDelay}", new {
+                    rescheduleAfter = jitteredDelay.ToString()
                 });
-                Requeue(entity, n);
+                Requeue(entity, jitteredDelay);
             }
             catch (RetryException e)
             {
@@ -862,6 +885,42 @@ namespace Alethic.Auth0.Operator.Controllers
             var jitterFactor = 0.75 + (Random.Shared.NextDouble() * 0.5);
             return TimeSpan.FromSeconds(ExceptionRetryBaseSeconds * jitterFactor);
         }
+
+        /// <summary>
+        /// Floor for the rate-limit requeue delay. The SDK's `X-RateLimit-Reset` hint is
+        /// authoritative when present, but we never requeue sooner than this — defensive
+        /// against missing/zero reset values and against the multi-pod thundering-herd risk
+        /// where every pod racing the exact reset instant would re-hammer the API.
+        /// </summary>
+        internal static readonly TimeSpan RateLimitRequeueFloor = TimeSpan.FromMinutes(1);
+
+        // F4 (LA-RF-81): testability seam. The jitter factor source is injectable so the
+        // `RateLimitApiException_RequeueDelay_AppliesJitterWithinTwentyPercentOfResetHint`
+        // test can drive the boundaries deterministically. Production uses
+        // <see cref="Random.Shared"/>. Internal — never expose on the public surface.
+        internal static Func<double> RateLimitJitterSampler { get; set; } = static () => Random.Shared.NextDouble();
+
+        /// <summary>
+        /// Applies ±20% jitter to <paramref name="baseDelay"/> and clamps the result back
+        /// up to <paramref name="floor"/> if jitter would push it below. Order matters:
+        /// floor is applied first by the caller, then jitter, then re-clamp — so the floor
+        /// is the strict minimum requeue delay regardless of jitter direction.
+        /// </summary>
+        internal static TimeSpan ApplyRateLimitJitter(TimeSpan baseDelay, TimeSpan floor)
+        {
+            // factor ∈ [0.8, 1.2): NextDouble() ∈ [0,1) → 0.8 + (∈[0,1) * 0.4)
+            var jitterFactor = 0.8 + (RateLimitJitterSampler() * 0.4);
+            var jittered = TimeSpan.FromTicks((long)(baseDelay.Ticks * jitterFactor));
+            return jittered < floor ? floor : jittered;
+        }
+
+        /// <summary>
+        /// Auth0 status codes that are considered "retryable hint" for log facets — 429
+        /// (rate-limit) and any 5xx (transient upstream). The hint is purely advisory for
+        /// observability; the operator does not change retry behavior based on it.
+        /// </summary>
+        internal static bool IsAuth0RetryableStatus(int statusCode)
+            => statusCode == 429 || (statusCode >= 500 && statusCode <= 599);
     }
 
 }

--- a/src/Alethic.Auth0.Operator/Controllers/V1Controller.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1Controller.cs
@@ -876,8 +876,7 @@ namespace Alethic.Auth0.Operator.Controllers
         /// <returns>Random delay in seconds</returns>
         protected int GenerateRandomRetryDelay()
         {
-            var random = new Random();
-            return random.Next(MinRetryDelaySeconds, MaxRetryDelaySeconds + 1);
+            return Random.Shared.Next(MinRetryDelaySeconds, MaxRetryDelaySeconds + 1);
         }
 
         /// <summary>

--- a/src/Alethic.Auth0.Operator/Controllers/V1TenantController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1TenantController.cs
@@ -83,8 +83,7 @@ namespace Alethic.Auth0.Operator.Controllers
                 "enabled_locales",
                 "idle_session_lifetime",
                 "session_lifetime",
-                "sandbox_version",
-                "sandbox_versions_available"
+                "sandbox_version"
             };
         }
 

--- a/src/Alethic.Auth0.Operator/Controllers/V1TenantController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1TenantController.cs
@@ -476,6 +476,11 @@ namespace Alethic.Auth0.Operator.Controllers
 
         /// <summary>
         /// Compares two values for equality, handling nested hashtables and arrays.
+        /// Array comparison is order-insensitive (set semantics) — Auth0 reorders list-shaped
+        /// fields server-side (notably <c>enabled_locales</c>), so preserving order would
+        /// produce spurious drift on every reconcile. Aligned with
+        /// <see cref="V1TenantEntityController{TEntity, TConf, TApi}.AreValuesEqual"/> via the
+        /// shared <see cref="DriftComparison.AreArraysEqualOrderInsensitive"/> helper.
         /// </summary>
         /// <param name="left">First value to compare</param>
         /// <param name="right">Second value to compare</param>
@@ -499,16 +504,7 @@ namespace Alethic.Auth0.Operator.Controllers
                 var leftArray = leftEnum.Cast<object>().ToArray();
                 var rightArray = rightEnum.Cast<object>().ToArray();
 
-                if (leftArray.Length != rightArray.Length)
-                    return false;
-
-                for (int i = 0; i < leftArray.Length; i++)
-                {
-                    if (!AreValuesEqual(leftArray[i], rightArray[i]))
-                        return false;
-                }
-
-                return true;
+                return DriftComparison.AreArraysEqualOrderInsensitive(leftArray, rightArray, AreValuesEqual);
             }
 
             // Use standard equality comparison

--- a/src/Alethic.Auth0.Operator/Controllers/V1TenantEntityController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V1TenantEntityController.cs
@@ -1458,31 +1458,16 @@ namespace Alethic.Auth0.Operator.Controllers
 
         /// <summary>
         /// Compares two collections as sets (order-insensitive) based on their element content.
+        /// Thin wrapper preserving the legacy in-class call sites; delegates to the shared
+        /// <see cref="DriftComparison.AreArraysEqualOrderInsensitive"/> helper so the tenant
+        /// controller and entity controller share one implementation.
         /// </summary>
         /// <param name="leftArray">First collection</param>
         /// <param name="rightArray">Second collection</param>
         /// <returns>True if collections contain the same elements regardless of order</returns>
         internal static bool AreArraysEqualOrderInsensitive(object[] leftArray, object[] rightArray)
         {
-            if (leftArray.Length != rightArray.Length)
-                return false;
-
-            foreach (var leftItem in leftArray)
-            {
-                bool foundMatch = false;
-                foreach (var rightItem in rightArray)
-                {
-                    if (AreValuesEqual(leftItem, rightItem))
-                    {
-                        foundMatch = true;
-                        break;
-                    }
-                }
-                if (!foundMatch)
-                    return false;
-            }
-
-            return true;
+            return DriftComparison.AreArraysEqualOrderInsensitive(leftArray, rightArray, AreValuesEqual);
         }
 
         /// <summary>


### PR DESCRIPTION
Mirrors GitLab clone MR !3 — https://gitlab.seatgeekadmin.com/platform/auth0-operator-clone/-/merge_requests/3

## Commits (7)

- `390539a` Exclude `sandbox_versions_available` from A0Tenant drift detection (LA-RF-81)
- `929875d` Allowlist OAuth enum values through `DriftField.EnsureNoSecretShape` (LA-RF-81)
- `3443bb6` Thread `defaultNamespace` through connection-update write log (LA-RF-81)
- `9cea952` Add regression test guarding `sandbox_versions_available` drift exclusion (LA-RF-81)
- `021fc54` Add Auth0 rate-limit + error-channel observability fields and requeue jitter (LA-RF-81)
- `f2b4acf` Address code-review findings H1/H2/M1/M2/M3 on rate-limit jitter and write-log tests (LA-RF-81)
- `c7ccc7c` Address MR !3 rufus feedback: align tenant drift comparison, tighten `pfx` redaction, use `Random.Shared` (LA-RF-81)

## Themes

1. **Drift false-positive fixes** — `sandbox_versions_available` (A0Tenant) and OAuth-enum redaction allowlist (A0Connection waad); directly addresses the API-call spike documented after `1.1.1-pre.13` / `pre.15` rollouts.
2. **Rate-limit observability + jitter** — adds `auth0RateLimitResetUtc`, `auth0RetryableHint`, `auth0RequeueFloorSeconds`, `auth0RequeueAfterSeconds` Datadog-facetable structured fields plus one-sided `[1.0, 1.2)` jitter on the requeue floor.
3. **Connection-update namespace threading** — replaces hard-coded `"unknown"` with the real `defaultNamespace` on two `LogAuth0Write` call sites in `V1ConnectionController`.
4. **Tenant drift comparison alignment** — extracts `AreArraysEqualOrderInsensitive` into a shared `DriftComparison` helper so `V1TenantController` no longer spuriously flags reordered list fields (`enabled_locales`, etc.) as drift. Confirmed-existing exposure today.
5. **Code-review follow-ups** — `ContainsSegment` boundary helper for `pfx` redaction (replaces broad `Contains`), `Random.Shared` for `GenerateRandomRetryDelay`, and various structural/test improvements per internal + rufus review.

## Validation

- ✅ `dotnet test src/Alethic.Auth0.Operator.Tests/` → 71 passed / 0 failed / 0 skipped
- ✅ 0 build warnings
- ✅ Transcript 1.1 (`enable + disable single-connection golden path`) PASS against prod-US Auth0 (see `agent-vault/projects/auth0-operator/test-transcripts/execution-results/2026-05-20__00-19-00 - 1.1 - golden-path-pass.md`)
- ✅ CRD parity preserved — no entity surface area changed.