### PR TITLE
Add CODEOWNERS assigning @seatgeek/auth0-operator-maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @seatgeek/auth0-operator-maintainers


### PR DESCRIPTION
## Summary
- Re-introduces `.github/CODEOWNERS` assigning the entire repository to `@seatgeek/auth0-operator-maintainers`.
- Previously removed in #40 pending a visible team; the team is now available.

## Test plan
- [ ] Confirm GitHub recognizes the team and applies code-owner review requirements on subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)